### PR TITLE
Fix: Enable extension to work on non-www swmaestro.org pages 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,13 +7,19 @@
   },
   "description": "멘토링/특강 게시판에 시간표를 띄워줍니다.",
   "permissions": ["activeTab", "scripting"],
-  "host_permissions": ["https://swmaestro.org/*"],
+  "host_permissions": [
+    "https://swmaestro.org/*",
+    "https://www.swmaestro.org/*"
+  ],
   "action": {
     "default_popup": "popup.html"
   },
   "content_scripts": [
     {
-      "matches": ["https://www.swmaestro.org/sw/mypage/userAnswer/history.do*"],
+      "matches": [
+        "https://swmaestro.org/sw/mypage/userAnswer/history.do*",
+        "https://www.swmaestro.org/sw/mypage/userAnswer/history.do*"
+      ],
       "js": ["content.js"],
       "css": ["calendar.css"]
     }


### PR DESCRIPTION
Closes #1

## 📌 Summary
This pull request fixes an issue where the extension did not activate on `https://swmaestro.org` (without `www.`).

## ✅ Changes
- Updated `host_permissions` to include both `https://swmaestro.org/*` and `https://www.swmaestro.org/*`
- Updated `content_scripts.matches` to match both non-www and www versions of the target page

## 🐞 Problem
The extension previously only worked on:
- https://www.swmaestro.org/sw/mypage/userAnswer/history.do?menuNo=200047

But did **not** work on:
- https://swmaestro.org/sw/mypage/userAnswer/history.do?menuNo=200047

## 🚀 Result
After this fix, the extension works on both URL variants.

