### PR TITLE
Feat : add AddToCalendar Button for IOS/MACOS & README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # 소마 멘토링 시간표 (Chrome Extension)
+
 - 본인이 접수한 멘토링/특강 내역을 접수 내역 페이지에서 시간표 형태로 확인할 수 있습니다.
 - 각 내역을 날짜 별로 제목, 시간, 작성자명, 장소, 최대 인원수 순으로 표시합니다.
 - 접수한 내역 중 시간이 겹치는 내역이 있을 경우 붉은색 배경으로 표시됩니다.
+
+## HOW TO USE
+
+```bash
+git clone https://github.com/ymjoo12/soma-calendar.git somaCalendar
+```
+
+- 해당 레포지토리를 바로 클론하거나 포크해서 클론해주세요.
+
+![](https://i.imgur.com/yLEuLMn.png)
+
+- 크롬의 '확장 프로그램에서 압축해제된 확장 프로그램 로드'를 눌러주세요
+
+![](https://i.imgur.com/g4YfG0i.png)
+
+- 클론된 폴더를 열기 해주면 자동으로 확장 프로그램이 추가됩니다.

--- a/content.js
+++ b/content.js
@@ -1,13 +1,15 @@
 function normalizeTimeStr(time) {
-  const [h, m, s] = time.split(':');
-  return `${h.padStart(2, '0')}:${m.padStart(2, '0')}:${s.padStart(2, '0')}`;
+  const [h, m, s] = time.split(":");
+  return `${h.padStart(2, "0")}:${m.padStart(2, "0")}:${s.padStart(2, "0")}`;
 }
 
 function extractEventListFromHTML(html) {
-  const container = document.createElement('div');
+  const container = document.createElement("div");
   container.innerHTML = html;
 
-  const rows = container.querySelectorAll("#contentsList > div > div > div.boardlist > div.tbl-ovx > table > tbody > tr");
+  const rows = container.querySelectorAll(
+    "#contentsList > div > div > div.boardlist > div.tbl-ovx > table > tbody > tr"
+  );
   const events = [];
 
   for (const row of rows) {
@@ -21,9 +23,14 @@ function extractEventListFromHTML(html) {
     const title = tds[2].innerText.trim();
     const author = tds[3].innerText.trim();
     if (!url || !title || !author) continue;
-    
-    const dateHTML = tds[4].innerHTML.trim().replace(/&nbsp;/g, "").trim();
-    const [dateStr, timeRangeStr] = dateHTML.split("<br>").map(str => str.trim());
+
+    const dateHTML = tds[4].innerHTML
+      .trim()
+      .replace(/&nbsp;/g, "")
+      .trim();
+    const [dateStr, timeRangeStr] = dateHTML
+      .split("<br>")
+      .map((str) => str.trim());
     if (!dateStr || !timeRangeStr) continue;
 
     events.push({ url, title, author, dateStr, timeRangeStr });
@@ -33,11 +40,19 @@ function extractEventListFromHTML(html) {
 }
 
 function extractEventDetailFromHTML(html) {
-  const container = document.createElement('div');
+  const container = document.createElement("div");
   container.innerHTML = html;
 
-  const loc = container.querySelector("#board > div > div.top > div:nth-child(4) > div:nth-child(1) > div").innerText.trim();
-  const npeople = container.querySelector("#board > div > div.top > div:nth-child(4) > div:nth-child(2) > div").innerText.trim();
+  const loc = container
+    .querySelector(
+      "#board > div > div.top > div:nth-child(4) > div:nth-child(1) > div"
+    )
+    .innerText.trim();
+  const npeople = container
+    .querySelector(
+      "#board > div > div.top > div:nth-child(4) > div:nth-child(2) > div"
+    )
+    .innerText.trim();
 
   return { loc, npeople };
 }
@@ -46,7 +61,8 @@ async function getAllMentoringEvents() {
   const events = [];
 
   const baseUrl = location.href;
-  const totalStr = document.querySelector(".bbs-total strong.color-blue")?.nextSibling?.textContent;
+  const totalStr = document.querySelector(".bbs-total strong.color-blue")
+    ?.nextSibling?.textContent;
   const total = parseInt(totalStr?.replace(":", "")?.trim()) || 0;
   const totalPages = Math.ceil(total / 10);
 
@@ -61,17 +77,31 @@ async function getAllMentoringEvents() {
   }
 
   for (let ev of events) {
-    const datePart = ev.dateStr.split('(')[0].trim(); // "2025-04-10"
-    const [startTime, endTime] = ev.timeRangeStr.split("~").map(s => normalizeTimeStr(s.trim())); // "18:30:00"
-    
+    const datePart = ev.dateStr.split("(")[0].trim(); // "2025-04-10"
+    const [startTime, endTime] = ev.timeRangeStr
+      .split("~")
+      .map((s) => normalizeTimeStr(s.trim())); // "18:30:00"
+
     ev.startAt = new Date(`${datePart}T${startTime}`);
     ev.endAt = new Date(`${datePart}T${endTime}`);
-    ev.timeRangeStr = `${startTime.replace(/:\d{2}$/, "")} ~ ${endTime.replace(/:\d{2}$/, "")}`;
+    ev.timeRangeStr = `${startTime.replace(/:\d{2}$/, "")} ~ ${endTime.replace(
+      /:\d{2}$/,
+      ""
+    )}`;
   }
 
   events.sort((a, b) => a.startAt - b.startAt);
   return events;
 }
+
+const addToCalendarBtn = (ev) => {
+  if (isAppleDevice()) {
+    return `<button class="add-to-calendar" data-id="${ev.url}" style="margin-top: 4px; background-color: #1493D2; color:white; border-radius: 20px; padding:4px; width: 100%;">
+  📅 캘린더에 추가
+  </button>`;
+  }
+  return "";
+};
 
 async function generateCalendarElement() {
   const today = new Date();
@@ -85,42 +115,62 @@ async function generateCalendarElement() {
     const date = new Date(startDate);
     date.setDate(startDate.getDate() + i);
 
-    const weekday = ['일', '월', '화', '수', '목', '금', '토'][date.getDay()];
+    const weekday = ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
     const dayStr = `${date.getMonth() + 1}월 ${date.getDate()}일 (${weekday})`;
     const isToday = date.toDateString() === today.toDateString();
-    const filteredEvents = events.filter(ev => {
+    const filteredEvents = events.filter((ev) => {
       const eventDate = new Date(ev.startAt);
       return eventDate.toDateString() === date.toDateString();
     });
 
     days.push(`
       <div class="calendar-cell">
-        <div class="calendar-date ${isToday ? 'today' : ''}">${dayStr} ${isToday ? ' [오늘]' : ''}</div>
-        ${filteredEvents.map((ev, i) => {
-          const isConflict = i > 0 && filteredEvents[i - 1].endAt > ev.startAt || i < filteredEvents.length - 1 && filteredEvents[i + 1].startAt < ev.endAt;
-          return `
-            <div class="calendar-event ${isConflict ? 'conflict' : ''}" title="${ev.title}">
-              <a href="${ev.url}" style="margin-bottom: 4px; font-weight: bold;">
-                <div class="ellipsis-2-lines" style="color: #114C9D;">${ev.title}</div>
+        <div class="calendar-date ${isToday ? "today" : ""}">${dayStr} ${
+      isToday ? " [오늘]" : ""
+    }</div>
+        ${filteredEvents
+          .map((ev, i) => {
+            const isConflict =
+              (i > 0 && filteredEvents[i - 1].endAt > ev.startAt) ||
+              (i < filteredEvents.length - 1 &&
+                filteredEvents[i + 1].startAt < ev.endAt);
+            return `
+            <div class="calendar-event ${
+              isConflict ? "conflict" : ""
+            }" title="${ev.title}">
+              <a href="${
+                ev.url
+              }" style="margin-bottom: 4px; font-weight: bold;">
+                <div class="ellipsis-2-lines" style="color: #114C9D;">${
+                  ev.title
+                }</div>
                 <div style="">${ev.timeRangeStr} ${ev.author}</div>
               </a>
+              ${addToCalendarBtn(ev)}
             </div>
-          `}).join('')}
+          `;
+          })
+          .join("")}
       </div>
     `);
   }
 
-  const wrapper = document.createElement('div');
-  wrapper.id = 'history-calendar';
-  wrapper.innerHTML = days.join('');
+  const wrapper = document.createElement("div");
+  wrapper.id = "history-calendar";
+  wrapper.innerHTML = days.join("");
 
   return wrapper;
 }
 
 async function main() {
-  let target = document.querySelector("#contentsList > div > div > ul.tabs-st1.col2");
+  let target = document.querySelector(
+    "#contentsList > div > div > ul.tabs-st1.col2"
+  );
   let newElement = await generateCalendarElement();
+
   target.after(newElement);
+  const events = await getAllMentoringEvents();
+  attachCalendarButtons(events);
 }
 
 async function updateCalendarElement() {
@@ -132,14 +182,82 @@ async function updateCalendarElement() {
     const eventDetails = extractEventDetailFromHTML(html);
     const { loc, npeople } = eventDetails;
     let target = ev.querySelector("a > div:nth-child(2)");
-    let newElement = document.createElement('div');
+    let newElement = document.createElement("div");
     newElement.innerHTML = `<div style="">${loc} / ${npeople}</div>`;
     target.after(newElement);
   }
 }
 
-main().then(() => {
-  updateCalendarElement();
-}).catch(err => {
-  console.error(err);
-});
+function attachCalendarButtons(events) {
+  document.querySelectorAll(".add-to-calendar").forEach((btn) => {
+    btn.addEventListener("click", (e) => {
+      const url = btn.dataset.id;
+      const ev = events.find((ev) => ev.url === url);
+      if (!ev) return;
+
+      const icsContent = generateICS(ev);
+      const blob = new Blob([icsContent], { type: "text/calendar" });
+      const link = document.createElement("a");
+      link.href = URL.createObjectURL(blob);
+      link.download = `${ev.title.replace(/\s+/g, "_")}.ics`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    });
+  });
+}
+
+function isAppleDevice() {
+  return /Macintosh|iPhone|iPad|iPod/.test(navigator.userAgent);
+}
+
+function generateICS(event) {
+  const pad = (n) => n.toString().padStart(2, "0");
+  const toICSDate = (date) => {
+    return (
+      date.getUTCFullYear().toString() +
+      pad(date.getUTCMonth() + 1) +
+      pad(date.getUTCDate()) +
+      "T" +
+      pad(date.getUTCHours()) +
+      pad(date.getUTCMinutes()) +
+      pad(date.getUTCSeconds()) +
+      "Z"
+    );
+  };
+
+  const start = toICSDate(event.startAt);
+  const end = toICSDate(event.endAt);
+  const title = event.title.replace(/\n/g, " ");
+  const description = `멘토: ${event.author}`;
+  const location = event.loc || "장소 미정";
+  const url = event.url;
+
+  return `BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+SUMMARY:${title}
+DTSTART:${start}
+DTEND:${end}
+DESCRIPTION:${description}\\n${url}
+LOCATION:${location}
+URL:${url}
+STATUS:CONFIRMED
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT10M
+ACTION:DISPLAY
+DESCRIPTION:Event Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR`.replace(/\n/g, "\r\n");
+}
+
+main()
+  .then(() => {
+    updateCalendarElement();
+  })
+  .catch((err) => {
+    console.error(err);
+  });


### PR DESCRIPTION
# Feat : add AddToCalendar Button for IOS/MACOS & README update
## 📌 Summary
- 해당 PR은 IOS/MACOS를 사용하는 유저들에게 ics 파일을 다운로드하여 실행만 하면 바로 캘린더에 일정을 추가할 수 있는 버튼을 추가한 버전입니다.
- 추가적으로 사용하기 어려운 분들을 위한 크롬 익스텐션 사용법도 추가해놓았습니다.

## ✅ Changes
- IOS/MAC 기기로 사용하는 유저들에 한해 버튼을 보여줍니다
- 버튼을 누르면 해당 멘토링 특강의 Ics 파일이 생성되어 다운로드받습니다
- 다운로드된 Ics 파일을 실행하면 캘린더에 바로 추가할 수 있습니다
- Readme에 크롬 익스텐션 사용법이 추가되었습니다.

## 🐞 Problem
- 저도 멘토링 신청하면서 항상 소마 캘린더를 보고 이걸 그대로 캘린더에 옮기기 귀찮아서 추가했습니다 😅

## 🙋‍♀️ Notes
혹시 잘못된 부분이 있으시면 언제든 말씀 주세요!
code에 Prettier 설정을 해놔서 따옴표가 바뀌었네요😅 혹시 선호하지 않으시면 돌려놓겠습니다,,