### PR TITLE
feat: 가독성 향상을 위해 지나간 강의는 회색으로 표시

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+README.md
+popup.html
+
+assets/
+icons/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,13 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "consistent",
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "proseWrap": "preserve"
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Youngmin Joo
+Copyright (c) 2025-2026 Youngmin Joo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/manifest.json
+++ b/manifest.json
@@ -14,17 +14,26 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*.swmaestro.ai/sw/mypage/userAnswer/history.do*", "https://swmaestro.ai/sw/mypage/userAnswer/history.do*"],
+      "matches": [
+        "https://*.swmaestro.ai/sw/mypage/userAnswer/history.do*",
+        "https://swmaestro.ai/sw/mypage/userAnswer/history.do*"
+      ],
       "js": ["src/utils.js", "src/content.js"],
       "css": ["src/calendar.css"]
     },
     {
-      "matches":["https://*.swmaestro.ai/sw/mypage/mentoLec/list.do?**", "https://swmaestro.ai/sw/mypage/mentoLec/list.do?*"],
+      "matches": [
+        "https://*.swmaestro.ai/sw/mypage/mentoLec/list.do?**",
+        "https://swmaestro.ai/sw/mypage/mentoLec/list.do?*"
+      ],
       "js": ["src/utils.js", "src/lecture.js"],
       "css": ["src/calendar.css"]
     },
     {
-      "matches":["https://*.swmaestro.ai/sw/mypage/mentoLec/view.do*", "https://swmaestro.ai/sw/mypage/mentoLec/view.do*"],
+      "matches": [
+        "https://*.swmaestro.ai/sw/mypage/mentoLec/view.do*",
+        "https://swmaestro.ai/sw/mypage/mentoLec/view.do*"
+      ],
       "js": ["src/utils.js", "src/lecture-item.js"]
     }
   ],

--- a/popup.js
+++ b/popup.js
@@ -1,12 +1,14 @@
 // popup.js
 
 const STORE_LINKS = {
-  chrome: "https://chromewebstore.google.com/detail/nlemmjbkihccbkdaihfgijnepogepoob",
-  firefox: "https://addons.mozilla.org/firefox/addon/%EC%86%8C%EB%A7%88-%EB%A9%98%ED%86%A0%EB%A7%81-%EC%8B%9C%EA%B0%84%ED%91%9C",
+  chrome:
+    "https://chromewebstore.google.com/detail/nlemmjbkihccbkdaihfgijnepogepoob",
+  firefox:
+    "https://addons.mozilla.org/firefox/addon/%EC%86%8C%EB%A7%88-%EB%A9%98%ED%86%A0%EB%A7%81-%EC%8B%9C%EA%B0%84%ED%91%9C",
 };
 
 function compareVersions(v1, v2) {
-  const toNums = (v) => v.split('.').map(Number);
+  const toNums = (v) => v.split(".").map(Number);
   const [a1, b1, c1, d1] = toNums(v1);
   const [a2, b2, c2, d2] = toNums(v2);
 
@@ -17,7 +19,9 @@ function compareVersions(v1, v2) {
 }
 
 function getStoreLink() {
-  return /Firefox/i.test(navigator.userAgent) ? STORE_LINKS.firefox : STORE_LINKS.chrome;
+  return /Firefox/i.test(navigator.userAgent)
+    ? STORE_LINKS.firefox
+    : STORE_LINKS.chrome;
 }
 
 document.getElementById("store-link").href = getStoreLink();
@@ -25,15 +29,15 @@ document.getElementById("store-link").href = getStoreLink();
 const localVersion = chrome.runtime.getManifest().version;
 
 fetch("https://api.github.com/repos/ymjoo12/soma-calendar/releases/latest")
-  .then(res => res.json())
-  .then(data => {
+  .then((res) => res.json())
+  .then((data) => {
     const latest = data.tag_name;
     const el = document.getElementById("version-status");
     if (compareVersions(localVersion, latest) >= 0) {
       el.textContent = `✅ 최신 버전입니다: ${localVersion}`;
     } else {
       el.textContent = `🔁 업데이트 가능: ${localVersion} → ${latest}`;
-      el.style.color = 'red';
+      el.style.color = "red";
     }
   })
   .catch(() => {

--- a/src/calendar.css
+++ b/src/calendar.css
@@ -15,7 +15,7 @@
 
 .calendar-cell {
   padding: 6px;
-  background: white; 
+  background: white;
 }
 
 .calendar-date {
@@ -49,6 +49,13 @@
 
 .conflict {
   background: #ffe8e8;
+}
+
+/* 가독성 향상을 위해 지나간 강의 카드는 회색으로 표시 */
+.ended {
+  background: #f6f6f6;
+  color: #777;
+  opacity: 0.6;
 }
 
 /* Text title styling */
@@ -146,7 +153,7 @@
 .info-group {
   display: inline-block;
   padding: 8px;
-  font-size: larger; 
+  font-size: larger;
   font-weight: bold;
   width: 100%;
 }

--- a/src/calendar.css
+++ b/src/calendar.css
@@ -52,7 +52,12 @@
 }
 
 /* 가독성 향상을 위해 지나간 강의 카드는 회색으로 표시 */
-.ended {
+.ended,
+.ended .text-title,
+.ended .info-group,
+.ended .export-btn,
+.ended .gcal-btn,
+.ended .cancel-btn {
   background: #f6f6f6;
   color: #777;
   opacity: 0.6;

--- a/src/calendar.css
+++ b/src/calendar.css
@@ -40,7 +40,9 @@
   border-radius: 6px;
   margin-top: 6px;
   box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
-  transition: box-shadow 0.2s ease, opacity 0.2s ease;
+  transition:
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
 }
 
 .calendar-lecture:hover {
@@ -65,8 +67,9 @@
 
 /* Text title styling */
 .text-title {
-  color: #114C9D;
+  color: #114c9d;
   display: -webkit-box;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
@@ -92,7 +95,9 @@
   max-width: 300px;
   display: none;
   pointer-events: none; /* 팝업이 마우스 이벤트를 가로채지 않도록 설정 */
-  transition: left 0.05s, top 0.05s; /* 부드러운 이동 효과 추가 */
+  transition:
+    left 0.05s,
+    top 0.05s; /* 부드러운 이동 효과 추가 */
 }
 
 .overlap-popup h4 {
@@ -169,7 +174,9 @@
   overflow: hidden;
 }
 
-.export-btn, .gcal-btn, .cancel-btn {
+.export-btn,
+.gcal-btn,
+.cancel-btn {
   flex: 1;
   background-color: #00000011;
   color: #222;
@@ -179,7 +186,9 @@
   text-align: center;
   border: none;
   cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
   border-right: 0.5px solid;
   border-color: #222;
   white-space: nowrap;
@@ -192,7 +201,7 @@
 
 .export-btn:hover,
 .gcal-btn:hover {
-  background-color: #114C9Dcc;
+  background-color: #114c9dcc;
   color: white;
   border-right: none;
 }

--- a/src/content.js
+++ b/src/content.js
@@ -10,9 +10,9 @@ function createCalendarButton(className, label, title, url, extraClass = "") {
   return button;
 }
 
-function createCalendarLectureElement(ev, isConflict, isAlreadyPassed) {
+function createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded) {
   const lectureElement = document.createElement("div");
-  lectureElement.className = `calendar-lecture ${isConflict ? "conflict" : ""}`.trim();
+  lectureElement.className = `calendar-lecture ${isConflict ? "conflict" : ""} ${isEnded ? "ended" : ""}`.trim();
   lectureElement.title = ev.title;
 
   const infoLink = document.createElement("a");
@@ -94,7 +94,8 @@ async function generateCalendarElement() {
         (index < filteredEvents.length - 1 &&
           filteredEvents[index + 1].startAt < ev.endAt);
       const isAlreadyPassed = ev.startAt < today;
-      cell.appendChild(createCalendarLectureElement(ev, isConflict, isAlreadyPassed));
+      const isEnded = ev.endAt < today;
+      cell.appendChild(createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded));
     });
 
     wrapper.appendChild(cell);
@@ -115,24 +116,24 @@ async function main() {
 function generateGoogleCalendarURL(lecture) {
   // URL 인코딩 함수
   const encode = (str) => encodeURIComponent(str).replace(/%20/g, '+');
-  
+
   // 구글 캘린더 기본 URL
   const baseUrl = 'https://calendar.google.com/calendar/render?action=TEMPLATE';
-  
+
   // 제목 추가
   const title = `&text=${encode(lecture.title)}`;
-  
+
   // 시작 및 종료 시간 추가 (ISO 형식으로 변환)
   const startTime = lecture.startAt.toISOString().replace(/-|:|\.\d+/g, '');
   const endTime = lecture.endAt.toISOString().replace(/-|:|\.\d+/g, '');
   const dates = `&dates=${startTime}/${endTime}`;
-  
+
   // 위치 추가
   const location = lecture.loc ? `&location=${encode(lecture.loc)}` : '';
-  
+
   // 설명 추가 (멘토 정보와 URL 포함)
   const description = `&details=${encode(`멘토: ${lecture.author}\n${lecture.url}`)}`;
-  
+
   // 완성된 URL 반환
   return `${baseUrl}${title}${dates}${location}${description}`;
 }
@@ -157,7 +158,7 @@ async function updateCalendarElement() {
     if (!lecture.isApproved) {
       npeopleElem.style.color = "red";
     }
-    
+
     // ICS 내보내기 버튼 이벤트 리스너
     let exportBtn = ev.querySelector(".export-btn");
     exportBtn.addEventListener("click", (e) => {
@@ -170,14 +171,14 @@ async function updateCalendarElement() {
       link.click();
       document.body.removeChild(link);
     });
-    
+
     // 구글 캘린더 버튼 이벤트 리스너
     let gcalBtn = ev.querySelector(".gcal-btn");
     gcalBtn.addEventListener("click", (e) => {
       const googleCalendarURL = generateGoogleCalendarURL(lecture);
       window.open(googleCalendarURL, '_blank');
     });
-    
+
     // 취소 버튼 이벤트 리스너
     let cancelBtn = ev.querySelector(".cancel-btn");
     cancelBtn.addEventListener("click", (e) => {

--- a/src/content.js
+++ b/src/content.js
@@ -155,7 +155,7 @@ async function updateCalendarElement() {
     locElem.innerText = loc;
     let npeopleElem = ev.querySelector('[data-role="npeople"]');
     npeopleElem.innerText = npeople + (lecture.isApproved ? " [개설 확정]" : " [미승인]");
-    if (!lecture.isApproved) {
+    if (!lecture.isApproved && !ev.classList.contains("ended")) {  // 가독성을 위해 이미 지나간 강의는 미승인 글자색 강조 X
       npeopleElem.style.color = "red";
     }
 

--- a/src/content.js
+++ b/src/content.js
@@ -10,9 +10,15 @@ function createCalendarButton(className, label, title, url, extraClass = "") {
   return button;
 }
 
-function createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded) {
+function createCalendarLectureElement(
+  ev,
+  isConflict,
+  isAlreadyPassed,
+  isEnded,
+) {
   const lectureElement = document.createElement("div");
-  lectureElement.className = `calendar-lecture ${isConflict ? "conflict" : ""} ${isEnded ? "ended" : ""}`.trim();
+  lectureElement.className =
+    `calendar-lecture ${isConflict ? "conflict" : ""} ${isEnded ? "ended" : ""}`.trim();
   lectureElement.title = ev.title;
 
   const infoLink = document.createElement("a");
@@ -45,14 +51,36 @@ function createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded) 
   npeopleElement.style.fontSize = "smaller";
   npeopleElement.textContent = "인원수 로딩중..";
 
-  infoLink.append(titleElement, authorElement, timeElement, locElement, npeopleElement);
+  infoLink.append(
+    titleElement,
+    authorElement,
+    timeElement,
+    locElement,
+    npeopleElement,
+  );
 
   const buttonGroup = document.createElement("div");
   buttonGroup.className = "button-group";
   buttonGroup.append(
-    createCalendarButton("export-btn", "💾 ICS", "Export (ICS로 내보내기)", ev.url),
-    createCalendarButton("gcal-btn", "📅 구글", "Add to Google Calendar", ev.url),
-    createCalendarButton("cancel-btn", "❌ 취소", "Cancel (접수 취소)", ev.url, isAlreadyPassed ? "already" : ""),
+    createCalendarButton(
+      "export-btn",
+      "💾 ICS",
+      "Export (ICS로 내보내기)",
+      ev.url,
+    ),
+    createCalendarButton(
+      "gcal-btn",
+      "📅 구글",
+      "Add to Google Calendar",
+      ev.url,
+    ),
+    createCalendarButton(
+      "cancel-btn",
+      "❌ 취소",
+      "Cancel (접수 취소)",
+      ev.url,
+      isAlreadyPassed ? "already" : "",
+    ),
   );
 
   lectureElement.append(infoLink, buttonGroup);
@@ -84,7 +112,8 @@ async function generateCalendarElement() {
     cell.className = `calendar-cell ${isToday ? "today-bg" : ""}`.trim();
 
     const dateElement = document.createElement("div");
-    dateElement.className = `calendar-date ${isToday ? "today-text" : ""}`.trim();
+    dateElement.className =
+      `calendar-date ${isToday ? "today-text" : ""}`.trim();
     dateElement.textContent = `${dayStr}${isToday ? " [오늘]" : ""}`;
     cell.appendChild(dateElement);
 
@@ -95,7 +124,9 @@ async function generateCalendarElement() {
           filteredEvents[index + 1].startAt < ev.endAt);
       const isAlreadyPassed = ev.startAt < today;
       const isEnded = ev.endAt < today;
-      cell.appendChild(createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded));
+      cell.appendChild(
+        createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded),
+      );
     });
 
     wrapper.appendChild(cell);
@@ -106,7 +137,7 @@ async function generateCalendarElement() {
 
 async function main() {
   let target = document.querySelector(
-    "#contentsList > div > div > ul.tabs-st1.col3"
+    "#contentsList > div > div > ul.tabs-st1.col3",
   );
   let newElement = await generateCalendarElement();
   target.after(newElement);
@@ -115,21 +146,21 @@ async function main() {
 // 구글 캘린더 이벤트 URL 생성 함수
 function generateGoogleCalendarURL(lecture) {
   // URL 인코딩 함수
-  const encode = (str) => encodeURIComponent(str).replace(/%20/g, '+');
+  const encode = (str) => encodeURIComponent(str).replace(/%20/g, "+");
 
   // 구글 캘린더 기본 URL
-  const baseUrl = 'https://calendar.google.com/calendar/render?action=TEMPLATE';
+  const baseUrl = "https://calendar.google.com/calendar/render?action=TEMPLATE";
 
   // 제목 추가
   const title = `&text=${encode(lecture.title)}`;
 
   // 시작 및 종료 시간 추가 (ISO 형식으로 변환)
-  const startTime = lecture.startAt.toISOString().replace(/-|:|\.\d+/g, '');
-  const endTime = lecture.endAt.toISOString().replace(/-|:|\.\d+/g, '');
+  const startTime = lecture.startAt.toISOString().replace(/-|:|\.\d+/g, "");
+  const endTime = lecture.endAt.toISOString().replace(/-|:|\.\d+/g, "");
   const dates = `&dates=${startTime}/${endTime}`;
 
   // 위치 추가
-  const location = lecture.loc ? `&location=${encode(lecture.loc)}` : '';
+  const location = lecture.loc ? `&location=${encode(lecture.loc)}` : "";
 
   // 설명 추가 (멘토 정보와 URL 포함)
   const description = `&details=${encode(`멘토: ${lecture.author}\n${lecture.url}`)}`;
@@ -141,12 +172,14 @@ function generateGoogleCalendarURL(lecture) {
 async function updateCalendarElement() {
   const eventElems = document.querySelectorAll("div.calendar-lecture");
   for (let ev of eventElems) {
-    const res = await fetch(ev.querySelector("a").href, { credentials: "include" });
+    const res = await fetch(ev.querySelector("a").href, {
+      credentials: "include",
+    });
     const html = await res.text();
     const eventDetails = extractLectureDetailFromHTML(html);
     const { loc, npeople, applyId } = eventDetails;
     let lecture = lectures.find(
-      (lec) => lec.url === ev.querySelector("a").href
+      (lec) => lec.url === ev.querySelector("a").href,
     );
     lecture.loc = loc;
     lecture.npeople = npeople;
@@ -154,8 +187,10 @@ async function updateCalendarElement() {
     let locElem = ev.querySelector('[data-role="loc"]');
     locElem.innerText = loc;
     let npeopleElem = ev.querySelector('[data-role="npeople"]');
-    npeopleElem.innerText = npeople + (lecture.isApproved ? " [개설 확정]" : " [미승인]");
-    if (!lecture.isApproved && !ev.classList.contains("ended")) {  // 가독성을 위해 이미 지나간 강의는 미승인 글자색 강조 X
+    npeopleElem.innerText =
+      npeople + (lecture.isApproved ? " [개설 확정]" : " [미승인]");
+    if (!lecture.isApproved && !ev.classList.contains("ended")) {
+      // 가독성을 위해 이미 지나간 강의는 미승인 글자색 강조 X
       npeopleElem.style.color = "red";
     }
 
@@ -176,7 +211,7 @@ async function updateCalendarElement() {
     let gcalBtn = ev.querySelector(".gcal-btn");
     gcalBtn.addEventListener("click", (e) => {
       const googleCalendarURL = generateGoogleCalendarURL(lecture);
-      window.open(googleCalendarURL, '_blank');
+      window.open(googleCalendarURL, "_blank");
     });
 
     // 취소 버튼 이벤트 리스너

--- a/src/lecture-item.js
+++ b/src/lecture-item.js
@@ -1,31 +1,31 @@
 getAllLectures().then((lectures) => {
-    const lecturesDictionary = convertLectureDictionaryWithoutDate(lectures);
-    const thisLectureId = getLectureId(location.href);
-    for(let i = 0; i< lectures.length;i++){
-        if(getLectureId(lectures[i].url) == thisLectureId){
-            return
-        }
+  const lecturesDictionary = convertLectureDictionaryWithoutDate(lectures);
+  const thisLectureId = getLectureId(location.href);
+  for (let i = 0; i < lectures.length; i++) {
+    if (getLectureId(lectures[i].url) == thisLectureId) {
+      return;
     }
+  }
 
-    const timeStr = document.querySelector(" div.top > div:nth-child(3) > div:nth-child(2) > div.c").innerText;
-    let [datePart, timePart] = timeStr.split(/\s{2,}/); // 공백 2개 이상 기준으로 나눔
-    const [startTime, endTime] = timePart.replace(/시/g, '').split(' ~ ');
+  const timeStr = document.querySelector(
+    " div.top > div:nth-child(3) > div:nth-child(2) > div.c",
+  ).innerText;
+  let [datePart, timePart] = timeStr.split(/\s{2,}/); // 공백 2개 이상 기준으로 나눔
+  const [startTime, endTime] = timePart.replace(/시/g, "").split(" ~ ");
 
-    datePart = datePart.replaceAll(".", "-")
+  datePart = datePart.replaceAll(".", "-");
 
-    if(!lecturesDictionary.hasOwnProperty(datePart)){
-        return
-    }
-    const targetList = lecturesDictionary[datePart]
-    for (let j = 0; j < targetList.length; j++) {
-        const [targetStartTime, targetEndTime ] = targetList[j].split(" ~ ");
-        if (getMin(endTime) <= getMin(targetStartTime))
-            break
-        
-        if (getMin(startTime) >= getMin(targetEndTime))
-            continue
-        
-        alert("시간이 겹치는 강의입니다. 신청하시기 전에 주의해주세요.")
-        break
-    }
+  if (!lecturesDictionary.hasOwnProperty(datePart)) {
+    return;
+  }
+  const targetList = lecturesDictionary[datePart];
+  for (let j = 0; j < targetList.length; j++) {
+    const [targetStartTime, targetEndTime] = targetList[j].split(" ~ ");
+    if (getMin(endTime) <= getMin(targetStartTime)) break;
+
+    if (getMin(startTime) >= getMin(targetEndTime)) continue;
+
+    alert("시간이 겹치는 강의입니다. 신청하시기 전에 주의해주세요.");
+    break;
+  }
 });

--- a/src/lecture.js
+++ b/src/lecture.js
@@ -1,323 +1,331 @@
-const lecturePopupDetailCache = new Map()
-const lecturePopupDetailRequests = new Map()
+const lecturePopupDetailCache = new Map();
+const lecturePopupDetailRequests = new Map();
 
 // 달력 항목에서 팝업 조회에 필요한 요소를 추출
 function getCalendarPopupElements(item) {
-    const trigger = item.firstElementChild?.tagName === "A"
-        ? item.firstElementChild
-        : item.querySelector("a")
-    const popup = item.querySelector(".calendarPop")
-    const detailLink = popup?.querySelector('a[href*="/sw/mypage/mentoLec/view.do"]')
+  const trigger =
+    item.firstElementChild?.tagName === "A"
+      ? item.firstElementChild
+      : item.querySelector("a");
+  const popup = item.querySelector(".calendarPop");
+  const detailLink = popup?.querySelector(
+    'a[href*="/sw/mypage/mentoLec/view.do"]',
+  );
 
-    return { trigger, popup, detailLink }
+  return { trigger, popup, detailLink };
 }
 
 // 사이트 기본 팝업이 실제로 열린 상태인지 판별
 function isCalendarPopupVisible(popup) {
-    if (!popup) {
-        return false
-    }
+  if (!popup) {
+    return false;
+  }
 
-    const style = getComputedStyle(popup)
-    return (
-        style.display !== "none" &&
-        style.visibility === "visible" &&
-        style.opacity !== "0"
-    )
+  const style = getComputedStyle(popup);
+  return (
+    style.display !== "none" &&
+    style.visibility === "visible" &&
+    style.opacity !== "0"
+  );
 }
 
 // 팝업 상세 정보를 그릴 컨테이너를 보장
 function getCalendarPopupDetailContainer(popup) {
-    const list = popup.querySelector(".calendarPop__list") || popup
-    let container = list.querySelector(".calendar-pop-extra")
+  const list = popup.querySelector(".calendarPop__list") || popup;
+  let container = list.querySelector(".calendar-pop-extra");
 
-    if (!container) {
-        container = document.createElement(list.tagName === "UL" ? "li" : "div")
-        container.className = "calendar-pop-extra"
-        list.appendChild(container)
-    }
+  if (!container) {
+    container = document.createElement(list.tagName === "UL" ? "li" : "div");
+    container.className = "calendar-pop-extra";
+    list.appendChild(container);
+  }
 
-    return container
+  return container;
 }
 
 // 불러온 상세 정보를 팝업 하단에 표시
 function renderCalendarPopupDetail(container, detail) {
-    container.className = "calendar-pop-extra"
-    container.replaceChildren()
+  container.className = "calendar-pop-extra";
+  container.replaceChildren();
 
-    if (detail.loading) {
-        container.classList.add("calendar-pop-extra-loading")
-        container.textContent = "상세 정보 로딩중..."
-        return
-    }
+  if (detail.loading) {
+    container.classList.add("calendar-pop-extra-loading");
+    container.textContent = "상세 정보 로딩중...";
+    return;
+  }
 
-    if (detail.error) {
-        container.classList.add("calendar-pop-extra-error")
-        container.textContent = "상세 정보를 불러오지 못했습니다."
-        return
-    }
+  if (detail.error) {
+    container.classList.add("calendar-pop-extra-error");
+    container.textContent = "상세 정보를 불러오지 못했습니다.";
+    return;
+  }
 
-    const peopleText = detail.totalCount
-        ? `${detail.appliedCount ?? 0}/${detail.totalCount}`
-        : detail.npeople || "정보 없음"
-    const fields = [
-        ["시간", detail.timeStr || "정보 없음"],
-        ["장소", detail.loc || "정보 없음"],
-        ["인원", peopleText],
-    ]
+  const peopleText = detail.totalCount
+    ? `${detail.appliedCount ?? 0}/${detail.totalCount}`
+    : detail.npeople || "정보 없음";
+  const fields = [
+    ["시간", detail.timeStr || "정보 없음"],
+    ["장소", detail.loc || "정보 없음"],
+    ["인원", peopleText],
+  ];
 
-    for (const [label, value] of fields) {
-        const row = document.createElement("div")
-        row.className = "calendar-pop-extra__row"
+  for (const [label, value] of fields) {
+    const row = document.createElement("div");
+    row.className = "calendar-pop-extra__row";
 
-        const labelElement = document.createElement("span")
-        labelElement.className = "calendar-pop-extra__label"
-        labelElement.textContent = label
+    const labelElement = document.createElement("span");
+    labelElement.className = "calendar-pop-extra__label";
+    labelElement.textContent = label;
 
-        const valueElement = document.createElement("span")
-        valueElement.className = "calendar-pop-extra__value"
-        valueElement.textContent = value
+    const valueElement = document.createElement("span");
+    valueElement.className = "calendar-pop-extra__value";
+    valueElement.textContent = value;
 
-        row.appendChild(labelElement)
-        row.appendChild(valueElement)
-        container.appendChild(row)
-    }
+    row.appendChild(labelElement);
+    row.appendChild(valueElement);
+    container.appendChild(row);
+  }
 }
 
 // 상세 페이지를 조회하고 결과를 캐시
 async function fetchCalendarPopupDetail(url) {
-    if (lecturePopupDetailCache.has(url)) {
-        return lecturePopupDetailCache.get(url)
-    }
+  if (lecturePopupDetailCache.has(url)) {
+    return lecturePopupDetailCache.get(url);
+  }
 
-    if (lecturePopupDetailRequests.has(url)) {
-        return lecturePopupDetailRequests.get(url)
-    }
+  if (lecturePopupDetailRequests.has(url)) {
+    return lecturePopupDetailRequests.get(url);
+  }
 
-    const request = fetch(url, { credentials: "include" })
-        .then((res) => {
-            if (!res.ok) {
-                throw new Error(`Failed to fetch popup detail: ${res.status}`)
-            }
+  const request = fetch(url, { credentials: "include" })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`Failed to fetch popup detail: ${res.status}`);
+      }
 
-            return res.text()
-        })
-        .then((html) => {
-            const detail = extractLectureDetailFromHTML(html)
-            lecturePopupDetailCache.set(url, detail)
-            return detail
-        })
-        .finally(() => {
-            lecturePopupDetailRequests.delete(url)
-        })
+      return res.text();
+    })
+    .then((html) => {
+      const detail = extractLectureDetailFromHTML(html);
+      lecturePopupDetailCache.set(url, detail);
+      return detail;
+    })
+    .finally(() => {
+      lecturePopupDetailRequests.delete(url);
+    });
 
-    lecturePopupDetailRequests.set(url, request)
-    return request
+  lecturePopupDetailRequests.set(url, request);
+  return request;
 }
 
 // 현재 열린 팝업에 상세 정보를 채워 넣기
 async function enrichCalendarPopup(item) {
-    const { popup, detailLink } = getCalendarPopupElements(item)
+  const { popup, detailLink } = getCalendarPopupElements(item);
 
-    if (!popup || !detailLink || !isCalendarPopupVisible(popup)) {
-        return
-    }
+  if (!popup || !detailLink || !isCalendarPopupVisible(popup)) {
+    return;
+  }
 
-    const container = getCalendarPopupDetailContainer(popup)
-    const cachedDetail = lecturePopupDetailCache.get(detailLink.href)
+  const container = getCalendarPopupDetailContainer(popup);
+  const cachedDetail = lecturePopupDetailCache.get(detailLink.href);
 
-    if (cachedDetail) {
-        renderCalendarPopupDetail(container, cachedDetail)
-        return
-    }
+  if (cachedDetail) {
+    renderCalendarPopupDetail(container, cachedDetail);
+    return;
+  }
 
-    if (container.dataset.state === "loading") {
-        return
-    }
+  if (container.dataset.state === "loading") {
+    return;
+  }
 
-    container.dataset.state = "loading"
-    renderCalendarPopupDetail(container, { loading: true })
+  container.dataset.state = "loading";
+  renderCalendarPopupDetail(container, { loading: true });
 
-    try {
-        const detail = await fetchCalendarPopupDetail(detailLink.href)
-        container.dataset.state = "loaded"
-        renderCalendarPopupDetail(container, detail)
-    } catch (error) {
-        container.dataset.state = "error"
-        renderCalendarPopupDetail(container, { error: true })
-        console.error(error)
-    }
+  try {
+    const detail = await fetchCalendarPopupDetail(detailLink.href);
+    container.dataset.state = "loaded";
+    renderCalendarPopupDetail(container, detail);
+  } catch (error) {
+    container.dataset.state = "error";
+    renderCalendarPopupDetail(container, { error: true });
+    console.error(error);
+  }
 }
 
 // 팝업 열림 애니메이션 타이밍을 고려해 여러 번 재시도
 function scheduleCalendarPopupEnrichment(item) {
-    const retryDelays = [0, 100, 300, 700]
+  const retryDelays = [0, 100, 300, 700];
 
-    for (const delay of retryDelays) {
-        window.setTimeout(() => {
-            enrichCalendarPopup(item)
-        }, delay)
-    }
+  for (const delay of retryDelays) {
+    window.setTimeout(() => {
+      enrichCalendarPopup(item);
+    }, delay);
+  }
 }
 
 // 달력 팝업 열림을 감지해 상세 정보 로딩을 연결
 function observeCalendarPopups() {
-    const calendarItems = document.querySelectorAll("li.category")
+  const calendarItems = document.querySelectorAll("li.category");
 
-    document.addEventListener("click", (event) => {
-        const trigger = event.target.closest("li.category > a")
-        const item = trigger?.closest("li.category")
+  document.addEventListener(
+    "click",
+    (event) => {
+      const trigger = event.target.closest("li.category > a");
+      const item = trigger?.closest("li.category");
 
-        if (!item) {
-            return
-        }
+      if (!item) {
+        return;
+      }
 
-        scheduleCalendarPopupEnrichment(item)
-    }, { capture: true })
+      scheduleCalendarPopupEnrichment(item);
+    },
+    { capture: true },
+  );
 
-    for (const item of calendarItems) {
-        const { trigger, popup, detailLink } = getCalendarPopupElements(item)
+  for (const item of calendarItems) {
+    const { trigger, popup, detailLink } = getCalendarPopupElements(item);
 
-        if (!trigger || !popup || !detailLink) {
-            continue
-        }
-
-        trigger.addEventListener("click", () => {
-            scheduleCalendarPopupEnrichment(item)
-        })
-
-        const observer = new MutationObserver(() => {
-            if (trigger.classList.contains("active")) {
-                scheduleCalendarPopupEnrichment(item)
-            }
-        })
-
-        observer.observe(trigger, {
-            attributes: true,
-            attributeFilter: ["class"],
-        })
-
-        if (trigger.classList.contains("active")) {
-            scheduleCalendarPopupEnrichment(item)
-        }
+    if (!trigger || !popup || !detailLink) {
+      continue;
     }
+
+    trigger.addEventListener("click", () => {
+      scheduleCalendarPopupEnrichment(item);
+    });
+
+    const observer = new MutationObserver(() => {
+      if (trigger.classList.contains("active")) {
+        scheduleCalendarPopupEnrichment(item);
+      }
+    });
+
+    observer.observe(trigger, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    if (trigger.classList.contains("active")) {
+      scheduleCalendarPopupEnrichment(item);
+    }
+  }
 }
 
 function renderConflictLectures(popupElement, conflictingLectures) {
-    popupElement.replaceChildren()
+  popupElement.replaceChildren();
 
-    const title = document.createElement("h4")
-    title.textContent = "겹치는 멘토링 목록"
-    popupElement.appendChild(title)
+  const title = document.createElement("h4");
+  title.textContent = "겹치는 멘토링 목록";
+  popupElement.appendChild(title);
 
-    for (const lecture of conflictingLectures) {
-        const lectureElement = document.createElement("div")
-        lectureElement.className = "overlap-lecture"
+  for (const lecture of conflictingLectures) {
+    const lectureElement = document.createElement("div");
+    lectureElement.className = "overlap-lecture";
 
-        const titleRow = document.createElement("div")
-        const titleStrong = document.createElement("strong")
-        titleStrong.textContent = lecture.title
-        titleRow.appendChild(titleStrong)
+    const titleRow = document.createElement("div");
+    const titleStrong = document.createElement("strong");
+    titleStrong.textContent = lecture.title;
+    titleRow.appendChild(titleStrong);
 
-        const authorRow = document.createElement("div")
-        authorRow.textContent = `멘토: ${lecture.author}`
+    const authorRow = document.createElement("div");
+    authorRow.textContent = `멘토: ${lecture.author}`;
 
-        const timeRow = document.createElement("div")
-        timeRow.textContent = `일시: ${lecture.dateStr} ${lecture.timeRangeStr}`
+    const timeRow = document.createElement("div");
+    timeRow.textContent = `일시: ${lecture.dateStr} ${lecture.timeRangeStr}`;
 
-        lectureElement.append(titleRow, authorRow, timeRow)
-        popupElement.appendChild(lectureElement)
-    }
+    lectureElement.append(titleRow, authorRow, timeRow);
+    popupElement.appendChild(lectureElement);
+  }
 }
 
 getAllLectures().then((lectures) => {
-    const lecturesDictionary = convertLectureDictionary(lectures);
-    const lectureDates = document.querySelectorAll("#listFrm > div.boardlist.mt50 > table > tbody > tr > td:nth-child(4)");
-    
-    // 팝업 요소 생성
-    const popupElement = document.createElement('div');
-    popupElement.className = 'overlap-popup';
-    document.body.appendChild(popupElement);
-    
-    for (let i = 0; i < lectureDates.length; i++) {
-        const [datePart, timePart] = lectureDates[i].innerText.split("\n");
-        if (!lecturesDictionary.hasOwnProperty(datePart)) {
-            continue;
-        }
-        
-        let targetList = lecturesDictionary[datePart];
-        let [startMin, endMin] = timePart.split(" ~ ");
-        let hasConflict = false;
-        let conflictingLectures = [];
-        
-        // 현재 멘토링 정보 가져오기
-        const lectureRow = lectureDates[i].parentElement;
-        
-        for (let j = 0; j < targetList.length; j++) {
-            let [targetStartMin, targetEndMin] = targetList[j].split(" ~ ");
+  const lecturesDictionary = convertLectureDictionary(lectures);
+  const lectureDates = document.querySelectorAll(
+    "#listFrm > div.boardlist.mt50 > table > tbody > tr > td:nth-child(4)",
+  );
 
-            if (getMin(endMin) <= getMin(targetStartMin)) {
-                continue;
-            }
+  // 팝업 요소 생성
+  const popupElement = document.createElement("div");
+  popupElement.className = "overlap-popup";
+  document.body.appendChild(popupElement);
 
-            if (getMin(startMin) >= getMin(targetEndMin)) {
-                continue;
-            }
-
-            // 자기 자신과의 비교는 건너뛰기
-            const conflictLecture = lectures.find(lec => 
-                lec.dateStr === datePart && 
-                lec.timeRangeStr === targetList[j]
-            );
-            
-            if (conflictLecture) {
-                hasConflict = true;
-                conflictingLectures.push(conflictLecture);
-            }
-        }
-        
-        if (hasConflict) {
-            // 행에 conflict-item 클래스 추가
-            lectureRow.classList.add('conflict-item');
-            lectureRow.style.color = 'red';
-            lectureRow.querySelector(".tit").style.color = 'red';
-            
-            // 마우스 이벤트 추가
-            lectureRow.addEventListener('mousemove', (e) => {
-                // 팝업 표시
-                renderConflictLectures(popupElement, conflictingLectures);
-                popupElement.style.display = 'block';
-                
-                // 마우스 커서 위치에 따라 팝업 위치 설정
-                const offset = 15; // 마우스 커서로부터의 간격
-                popupElement.style.left = (e.clientX + offset) + 'px';
-                popupElement.style.top = (e.clientY + offset) + 'px';
-                
-                // 팝업이 화면 밖으로 나가는지 확인하고 조정
-                const popupRect = popupElement.getBoundingClientRect();
-                if (popupRect.right > window.innerWidth) {
-                    popupElement.style.left = (e.clientX - popupRect.width - offset) + 'px';
-                }
-                if (popupRect.bottom > window.innerHeight) {
-                    popupElement.style.top = (e.clientY - popupRect.height - offset) + 'px';
-                }
-            });
-            
-            lectureRow.addEventListener('mouseleave', () => {
-                popupElement.style.display = 'none';
-            });
-        }
+  for (let i = 0; i < lectureDates.length; i++) {
+    const [datePart, timePart] = lectureDates[i].innerText.split("\n");
+    if (!lecturesDictionary.hasOwnProperty(datePart)) {
+      continue;
     }
-    
-    // 스크롤 시 팝업 숨기기 (마우스 이동 없이 스크롤만 할 경우 팝업 제거)
-    document.addEventListener('scroll', () => {
-        if (popupElement.style.display === 'block') {
-            const activeItem = document.querySelector('.conflict-item:hover');
-            if (!activeItem) {
-                popupElement.style.display = 'none';
-            }
+
+    let targetList = lecturesDictionary[datePart];
+    let [startMin, endMin] = timePart.split(" ~ ");
+    let hasConflict = false;
+    let conflictingLectures = [];
+
+    // 현재 멘토링 정보 가져오기
+    const lectureRow = lectureDates[i].parentElement;
+
+    for (let j = 0; j < targetList.length; j++) {
+      let [targetStartMin, targetEndMin] = targetList[j].split(" ~ ");
+
+      if (getMin(endMin) <= getMin(targetStartMin)) {
+        continue;
+      }
+
+      if (getMin(startMin) >= getMin(targetEndMin)) {
+        continue;
+      }
+
+      // 자기 자신과의 비교는 건너뛰기
+      const conflictLecture = lectures.find(
+        (lec) => lec.dateStr === datePart && lec.timeRangeStr === targetList[j],
+      );
+
+      if (conflictLecture) {
+        hasConflict = true;
+        conflictingLectures.push(conflictLecture);
+      }
+    }
+
+    if (hasConflict) {
+      // 행에 conflict-item 클래스 추가
+      lectureRow.classList.add("conflict-item");
+      lectureRow.style.color = "red";
+      lectureRow.querySelector(".tit").style.color = "red";
+
+      // 마우스 이벤트 추가
+      lectureRow.addEventListener("mousemove", (e) => {
+        // 팝업 표시
+        renderConflictLectures(popupElement, conflictingLectures);
+        popupElement.style.display = "block";
+
+        // 마우스 커서 위치에 따라 팝업 위치 설정
+        const offset = 15; // 마우스 커서로부터의 간격
+        popupElement.style.left = e.clientX + offset + "px";
+        popupElement.style.top = e.clientY + offset + "px";
+
+        // 팝업이 화면 밖으로 나가는지 확인하고 조정
+        const popupRect = popupElement.getBoundingClientRect();
+        if (popupRect.right > window.innerWidth) {
+          popupElement.style.left = e.clientX - popupRect.width - offset + "px";
         }
-    });
-    
-    observeCalendarPopups();
+        if (popupRect.bottom > window.innerHeight) {
+          popupElement.style.top = e.clientY - popupRect.height - offset + "px";
+        }
+      });
+
+      lectureRow.addEventListener("mouseleave", () => {
+        popupElement.style.display = "none";
+      });
+    }
+  }
+
+  // 스크롤 시 팝업 숨기기 (마우스 이동 없이 스크롤만 할 경우 팝업 제거)
+  document.addEventListener("scroll", () => {
+    if (popupElement.style.display === "block") {
+      const activeItem = document.querySelector(".conflict-item:hover");
+      if (!activeItem) {
+        popupElement.style.display = "none";
+      }
+    }
+  });
+
+  observeCalendarPopups();
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,11 @@
-const PAGE_ONE = "1"
+const PAGE_ONE = "1";
 
 function parseHtmlDocument(html) {
   return new DOMParser().parseFromString(html, "text/html");
 }
 
-function setPageIndexToOne(url){
-  if(url === undefined){
+function setPageIndexToOne(url) {
+  if (url === undefined) {
     return undefined;
   }
   const _url = new URL(url);
@@ -14,14 +14,16 @@ function setPageIndexToOne(url){
 }
 
 function normalizeTimeStr(time) {
-    const [h, m, s] = time.split(':');
-    return `${h.padStart(2, '0')}:${m.padStart(2, '0')}:${s.padStart(2, '0')}`;
-  }
-  
+  const [h, m, s] = time.split(":");
+  return `${h.padStart(2, "0")}:${m.padStart(2, "0")}:${s.padStart(2, "0")}`;
+}
+
 function extractLectureListFromHTML(html) {
   const container = parseHtmlDocument(html);
 
-  const rows = container.querySelectorAll("#contentsList > div > div > div.boardlist > div.tbl-ovx > table > tbody > tr");
+  const rows = container.querySelectorAll(
+    "#contentsList > div > div > div.boardlist > div.tbl-ovx > table > tbody > tr",
+  );
   const lectures = [];
 
   for (const row of rows) {
@@ -35,7 +37,7 @@ function extractLectureListFromHTML(html) {
     const title = tds[2].innerText.trim();
     const author = tds[3].innerText.trim();
     if (!url || !title || !author) continue;
-    
+
     const [dateStr, timeRangeStr] = tds[4].innerText
       .replace(/\u00a0/g, " ")
       .split("\n")
@@ -45,9 +47,17 @@ function extractLectureListFromHTML(html) {
 
     const isApproved = tds[7].innerText.trim() === "OK";
     const params = new URL(url).searchParams;
-    const lectureId = params.get('qustnrSn');
+    const lectureId = params.get("qustnrSn");
 
-    lectures.push({ url, title, author, dateStr, timeRangeStr, isApproved, lectureId });
+    lectures.push({
+      url,
+      title,
+      author,
+      dateStr,
+      timeRangeStr,
+      isApproved,
+      lectureId,
+    });
   }
 
   return lectures;
@@ -55,14 +65,23 @@ function extractLectureListFromHTML(html) {
 
 function extractLectureDetailFromHTML(html) {
   const container = parseHtmlDocument(html);
-  const cancelBtn = container.querySelector("#contentsList > div > div > div.btn_w-st1.mt50 > button.btn-st1.bg-black_r");
+  const cancelBtn = container.querySelector(
+    "#contentsList > div > div > div.btn_w-st1.mt50 > button.btn-st1.bg-black_r",
+  );
   const getTopValue = (label) => {
-    const group = [...container.querySelectorAll("div.top .group")]
-      .find((item) => item.querySelector(".t")?.innerText.trim() === label);
-    return group?.querySelector(".c")?.innerText.replace(/\s+/g, " ").trim() || null;
+    const group = [...container.querySelectorAll("div.top .group")].find(
+      (item) => item.querySelector(".t")?.innerText.trim() === label,
+    );
+    return (
+      group?.querySelector(".c")?.innerText.replace(/\s+/g, " ").trim() || null
+    );
   };
   const npeople = getTopValue("모집인원");
-  const appliedSummary = container.querySelector(".total-normal.mt50")?.innerText.replace(/\s+/g, " ").trim() || "";
+  const appliedSummary =
+    container
+      .querySelector(".total-normal.mt50")
+      ?.innerText.replace(/\s+/g, " ")
+      .trim() || "";
   const appliedCount = appliedSummary.match(/\[(\d+)\s*명\]/)?.[1] || null;
   const totalCount = npeople?.match(/(\d+)/)?.[1] || null;
   return {
@@ -71,15 +90,16 @@ function extractLectureDetailFromHTML(html) {
     timeStr: getTopValue("강의날짜"),
     appliedCount,
     totalCount,
-    applyId: cancelBtn ? cancelBtn.getAttribute('onclick').split("'")[3] : null,
+    applyId: cancelBtn ? cancelBtn.getAttribute("onclick").split("'")[3] : null,
   };
 }
 
-async function getTotalPages(baseUrl){
+async function getTotalPages(baseUrl) {
   const res = await fetch(baseUrl, { credentials: "include" });
   const html = await res.text();
-  const container = parseHtmlDocument(html)
-  const totalStr = container.querySelector(".bbs-total strong.color-blue")?.nextSibling?.textContent
+  const container = parseHtmlDocument(html);
+  const totalStr = container.querySelector(".bbs-total strong.color-blue")
+    ?.nextSibling?.textContent;
   const total = parseInt(totalStr?.replace(":", "")?.trim()) || 0;
   const totalPages = Math.ceil(total / 10);
   return totalPages;
@@ -89,10 +109,12 @@ async function getAllLectures() {
   const lectures = [];
 
   const path = "/sw/mypage/userAnswer/history.do?menuNo=200047";
-  const totalPages = await getTotalPages(path)
+  const totalPages = await getTotalPages(path);
 
   for (let page = 1; page <= totalPages; page++) {
-    const res = await fetch(path + "&pageIndex=" + page, { credentials: "include" });
+    const res = await fetch(path + "&pageIndex=" + page, {
+      credentials: "include",
+    });
     const html = await res.text();
     const pageLectures = extractLectureListFromHTML(html);
     lectures.push(...pageLectures);
@@ -108,7 +130,7 @@ async function getAllLectures() {
     ev.endAt = new Date(`${datePart}T${endTime}`);
     ev.timeRangeStr = `${startTime.replace(/:\d{2}$/, "")} ~ ${endTime.replace(
       /:\d{2}$/,
-      ""
+      "",
     )}`;
   }
 
@@ -116,40 +138,40 @@ async function getAllLectures() {
   return lectures;
 }
 
-function getMin(timeStr){
+function getMin(timeStr) {
   let splitTime = timeStr.split(":");
-  return (parseInt(splitTime[0]) * 60) + parseInt(splitTime[1]) 
+  return parseInt(splitTime[0]) * 60 + parseInt(splitTime[1]);
 }
 
-function convertLectureDictionary(lectures){
-  let lecturesDictionary = Object()
-  for(let i=0;i<lectures.length;i++){
-      if(!lecturesDictionary.hasOwnProperty(lectures[i].dateStr)){
-        lecturesDictionary[lectures[i].dateStr] = []
-      }
-      lecturesDictionary[lectures[i].dateStr].push(lectures[i].timeRangeStr)
+function convertLectureDictionary(lectures) {
+  let lecturesDictionary = Object();
+  for (let i = 0; i < lectures.length; i++) {
+    if (!lecturesDictionary.hasOwnProperty(lectures[i].dateStr)) {
+      lecturesDictionary[lectures[i].dateStr] = [];
+    }
+    lecturesDictionary[lectures[i].dateStr].push(lectures[i].timeRangeStr);
   }
-  
-  return lecturesDictionary
+
+  return lecturesDictionary;
 }
 
-function convertLectureDictionaryWithoutDate(lectures){
-  let lecturesDictionary = Object()
-  for(let i=0;i<lectures.length;i++){
-    dateStrWithoutDate = lectures[i].dateStr.slice(0, -3)
-      if(!lecturesDictionary.hasOwnProperty(dateStrWithoutDate)){
-        lecturesDictionary[dateStrWithoutDate] = []
-      }
-      lecturesDictionary[dateStrWithoutDate].push(lectures[i].timeRangeStr)
+function convertLectureDictionaryWithoutDate(lectures) {
+  let lecturesDictionary = Object();
+  for (let i = 0; i < lectures.length; i++) {
+    dateStrWithoutDate = lectures[i].dateStr.slice(0, -3);
+    if (!lecturesDictionary.hasOwnProperty(dateStrWithoutDate)) {
+      lecturesDictionary[dateStrWithoutDate] = [];
+    }
+    lecturesDictionary[dateStrWithoutDate].push(lectures[i].timeRangeStr);
   }
-  
-  return lecturesDictionary
+
+  return lecturesDictionary;
 }
 
-function getLectureId(url){
+function getLectureId(url) {
   const params = new URL(url).searchParams;
-  const qustnrSn = params.get('qustnrSn');
-  return qustnrSn
+  const qustnrSn = params.get("qustnrSn");
+  return qustnrSn;
 }
 
 function cancelApply(applySn, qustnrSn) {
@@ -157,26 +179,26 @@ function cancelApply(applySn, qustnrSn) {
     fetch("/sw/mypage/mentoLec/applyCancel.json", {
       method: "POST",
       headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
+        "Content-Type": "application/x-www-form-urlencoded",
       },
       body: new URLSearchParams({
         id: applySn,
-        qustnrSn: qustnrSn
-      })
+        qustnrSn: qustnrSn,
+      }),
     })
-    .then(res => res.json())
-    .then(data => {
-      const { resultCode, cancelAt } = data;
-      if (resultCode === "success") {
-        if (cancelAt === "Y") {
-          alert("취소 하였습니다.");
+      .then((res) => res.json())
+      .then((data) => {
+        const { resultCode, cancelAt } = data;
+        if (resultCode === "success") {
+          if (cancelAt === "Y") {
+            alert("취소 하였습니다.");
+          } else {
+            alert("강의 날 이후 부터는 취소가 불가능 합니다.");
+          }
+          location.reload();
         } else {
-          alert("강의 날 이후 부터는 취소가 불가능 합니다.");
+          alert("작업에 실패하였습니다.");
         }
-        location.reload();
-      } else {
-        alert("작업에 실패하였습니다.");
-      }
-    });
+      });
   }
 }


### PR DESCRIPTION
## 작업 내용
- `new Date()`로 가져오는 현재 시각을 활용하여, 지나간 강의와 관련된 정보는 회색으로 표시해 가독성을 높였습니다
- `Prettier` 포매터 설정 파일을 추가하고, 코드 포매팅을 수행했습니다
  - `VS Code`의 경우, [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) 익스텐션을 설치한 뒤 `Format on Save` 옵션을 통해 손쉽게 포매팅할 수 있습니다
  - `VS Code`가 아니라면, 프로젝트 루트 디렉토리에서 `npx prettier --write .` 명령을 실행해 포매팅할 수 있습니다
- 라이선스 정보를 최신화했습니다
  - `2025` -> `2025-2026`

### AS-IS
<img width="1505" height="1200" alt="image" src="https://github.com/user-attachments/assets/a448a00c-598b-48fa-987d-2bc800dba2ae" />

### TO-BE
<img width="1505" height="1200" alt="image(1)" src="https://github.com/user-attachments/assets/9ebf85d3-1781-4b65-bc4f-b1af2cda0c95" />

