### PR TITLE
feat: HTML 셀렉터 구조 변경 대비 fallback 옵션 추가

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -137,7 +137,7 @@ async function generateCalendarElement() {
 
 async function main() {
   let target = document.querySelector(
-    "#contentsList > div > div > ul.tabs-st1.col3",
+    "#contentsList > div > div > ul.tabs-st1.col2",
   );
   let newElement = await generateCalendarElement();
   target.after(newElement);

--- a/src/content.js
+++ b/src/content.js
@@ -136,9 +136,10 @@ async function generateCalendarElement() {
 }
 
 async function main() {
-  let target = document.querySelector(
-    "#contentsList > div > div > ul.tabs-st1.col2",
-  );
+  let target =
+    document.querySelector("#contentsList > div > div > ul.tabs-st1.col2") ||
+    document.querySelector("#contentsList > div > div > ul.tabs-st1.col3"); // 셀렉터 fallback 옵션 추가
+
   let newElement = await generateCalendarElement();
   target.after(newElement);
 }


### PR DESCRIPTION
## 작업 내용
- 페이지 레이아웃 변경에 대응할 수 있도록 HTML 셀렉터 fallback 옵션을 추가했습니다

### AS-IS
```javascript
  let target = document.querySelector("#contentsList > div > div > ul.tabs-st1.col3");
```
### TO-BE
```javascript
  let target =
    document.querySelector("#contentsList > div > div > ul.tabs-st1.col2") ||
    document.querySelector("#contentsList > div > div > ul.tabs-st1.col3");
```
---
- 2026.04.14 레이아웃
<img width="1479" height="84" alt="image" src="https://github.com/user-attachments/assets/4ac84038-2a4b-446d-a512-9c34f741a164" />

- 2026.04.15 레이아웃
<img width="1459" height="111" alt="Screenshot 2026-04-15 at 7 25 33 PM" src="https://github.com/user-attachments/assets/84a56adc-a2f6-45b5-8eb7-0c6f5876725a" />
