### PR TITLE
Merge main into develop and bump manifest version to 26.4.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ git clone https://github.com/ymjoo12/soma-calendar.git
 | [@qyinm](https://github.com/qyinm) | 구글 캘린더 추가 기능 | [#22](https://github.com/ymjoo12/soma-calendar/pull/22) |
 | [@softwareDefine](https://github.com/softwareDefine) | 도메인 변경 및 레이아웃 변경 반영 | [#27](https://github.com/ymjoo12/soma-calendar/pull/27), [#29](https://github.com/ymjoo12/soma-calendar/pull/29) |
 | [@lickelon](https://github.com/lickelon) | 멘토링/특강 달력 활동 정보 요약 보기 | [#30](https://github.com/ymjoo12/soma-calendar/pull/30) |
-| [@doorcs](https://github.com/doorcs) | 지나간 강의 회색 표시 및 코드 포매팅 적용 | [#32](https://github.com/ymjoo12/soma-calendar/pull/32) |
+| [@doorcs](https://github.com/doorcs) | 지나간 강의 회색 표시, 코드 포매팅, 레이아웃 변경 fallback 추가 | [#32](https://github.com/ymjoo12/soma-calendar/pull/32), [#33](https://github.com/ymjoo12/soma-calendar/pull/33) |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "소마 멘토링 시간표",
-  "version": "26.4.14.0",
+  "version": "26.4.15.0",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",


### PR DESCRIPTION
This pull request includes minor updates to documentation and versioning. The `README.md` has been updated to reflect additional contributions for layout fallback changes, and the extension version has been incremented to `26.4.15.0` in `manifest.json`.

- Documentation update:
  * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R87): Updated the contribution entry for `@doorcs` to include "레이아웃 변경 fallback 추가" and referenced pull request #33.

- Version bump:
  * [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4): Increased the extension version from `26.4.14.0` to `26.4.15.0`.