### PR TITLE
fix: 익스텐션 중복 설치 시 캘린더가 여러 번 렌더링되는 버그 수정

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -136,6 +136,8 @@ async function generateCalendarElement() {
 }
 
 async function main() {
+  document.getElementById("history-calendar")?.remove();
+
   let target =
     document.querySelector("#contentsList > div > div > ul.tabs-st1.col2") ||
     document.querySelector("#contentsList > div > div > ul.tabs-st1.col3"); // 셀렉터 fallback 옵션 추가


### PR DESCRIPTION
익스텐션이 2개 설치되어있을 때 두 익스텐션 모두 캘린더를 렌더링하여 캘린더가 2번 보여서 수정하였습니다.

처음에는
`if (document.getElementById("history-calendar")) return;`
으로 할까 했는데, 이미 있다면 삭제를 하고 재렌더링하는 하는 방법을 선택하였습니다.

제가 JS, TS 쪽 지식은 많이 부족하여 리뷰로 남겨주시면 참고할 수 있도록 하겠습니다!