### PR TITLE
접수내역 달력 취소 동작을 실제 사이트 흐름에 맞게 수정

### DIFF
--- a/src/calendar.css
+++ b/src/calendar.css
@@ -211,11 +211,23 @@
   color: white;
 }
 
-.already {
+.past,
+.unavailable {
   cursor: not-allowed;
 }
 
-.already:hover {
-  background-color: #00000011;
-  color: #ff4444;
+.cancel-btn:disabled,
+.cancel-btn.past,
+.cancel-btn.unavailable {
+  background-color: #00000008;
+  color: #999999;
+  opacity: 0.45;
+  filter: grayscale(1);
+}
+
+.cancel-btn:disabled:hover,
+.cancel-btn.past:hover,
+.cancel-btn.unavailable:hover {
+  background-color: #00000008;
+  color: #999999;
 }

--- a/src/content.js
+++ b/src/content.js
@@ -1,12 +1,20 @@
 let lectures = [];
 
-function createCalendarButton(className, label, title, url, extraClass = "") {
+function createCalendarButton(
+  className,
+  label,
+  title,
+  url,
+  extraClass = "",
+  disabled = false,
+) {
   const button = document.createElement("button");
   button.className = extraClass ? `${className} ${extraClass}` : className;
   button.dataset.id = url;
   button.style.flex = "1";
   button.title = title;
   button.textContent = label;
+  button.disabled = disabled;
   return button;
 }
 
@@ -61,6 +69,7 @@ function createCalendarLectureElement(
 
   const buttonGroup = document.createElement("div");
   buttonGroup.className = "button-group";
+  const isCancelUnavailable = !ev.cancelId;
   buttonGroup.append(
     createCalendarButton(
       "export-btn",
@@ -77,9 +86,12 @@ function createCalendarLectureElement(
     createCalendarButton(
       "cancel-btn",
       "❌ 취소",
-      "Cancel (접수 취소)",
+      isCancelUnavailable
+        ? "Cancel unavailable (접수 취소 불가)"
+        : "Cancel (접수 취소)",
       ev.url,
-      isAlreadyPassed ? "already" : "",
+      isCancelUnavailable ? "unavailable" : isAlreadyPassed ? "past" : "",
+      isCancelUnavailable,
     ),
   );
 
@@ -178,13 +190,12 @@ async function updateCalendarElement() {
     });
     const html = await res.text();
     const eventDetails = extractLectureDetailFromHTML(html);
-    const { loc, npeople, applyId } = eventDetails;
+    const { loc, npeople } = eventDetails;
     let lecture = lectures.find(
       (lec) => lec.url === ev.querySelector("a").href,
     );
     lecture.loc = loc;
     lecture.npeople = npeople;
-    lecture.applyId = applyId;
     let locElem = ev.querySelector('[data-role="loc"]');
     locElem.innerText = loc;
     let npeopleElem = ev.querySelector('[data-role="npeople"]');
@@ -217,12 +228,11 @@ async function updateCalendarElement() {
 
     // 취소 버튼 이벤트 리스너
     let cancelBtn = ev.querySelector(".cancel-btn");
+    if (cancelBtn.disabled || lecture.startAt < new Date()) {
+      continue;
+    }
     cancelBtn.addEventListener("click", (e) => {
-      if (lecture.startAt < new Date()) {
-        alert("이미 지나간 강의는 취소할 수 없습니다.");
-      } else {
-        cancelApply(lecture.applyId, lecture.lectureId);
-      }
+      cancelApply(lecture.cancelId, lecture.lectureId, lecture.cancelGubun);
     });
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,8 +50,16 @@ function extractLectureListFromHTML(html) {
     if (!dateStr || !timeRangeStr) continue;
 
     const isApproved = tds[7].innerText.trim() === "OK";
+    const cancelHref = row
+      .querySelector('a[href*="delDate("]')
+      ?.getAttribute("href");
+    const cancelMatch = cancelHref?.match(
+      /delDate\('([^']+)'\s*,\s*'([^']+)'\s*,\s*'([^']+)'\)/,
+    );
     const params = new URL(url).searchParams;
-    const lectureId = params.get("qustnrSn");
+    const lectureId = cancelMatch?.[2] || params.get("qustnrSn");
+    const cancelId = cancelMatch?.[1] || null;
+    const cancelGubun = cancelMatch?.[3] || null;
 
     lectures.push({
       url,
@@ -61,6 +69,8 @@ function extractLectureListFromHTML(html) {
       timeRangeStr,
       isApproved,
       lectureId,
+      cancelId,
+      cancelGubun,
     });
   }
 
@@ -178,16 +188,27 @@ function getLectureId(url) {
   return qustnrSn;
 }
 
-function cancelApply(applySn, qustnrSn) {
+function cancelApply(cancelId, qustnrSn, gubun = "mentoLec") {
+  if (!cancelId || !qustnrSn) {
+    alert("취소할 수 없는 항목입니다.");
+    return;
+  }
+
+  if (typeof window.delDate === "function") {
+    window.delDate(cancelId, qustnrSn, gubun);
+    return;
+  }
+
   if (confirm("선택된 항목의 접수를 취소 하시겠습니까?")) {
-    fetch(`${getSwPathPrefix()}/sw/mypage/mentoLec/applyCancel.json`, {
+    fetch(`${getSwPathPrefix()}/sw/mypage/userAnswer/cancel.json`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: new URLSearchParams({
-        id: applySn,
-        qustnrSn: qustnrSn,
+        id: cancelId,
+        qustnrSn,
+        gubun,
       }),
     })
       .then((res) => res.json())
@@ -197,12 +218,15 @@ function cancelApply(applySn, qustnrSn) {
           if (cancelAt === "Y") {
             alert("취소 하였습니다.");
           } else {
-            alert("강의 날 이후 부터는 취소가 불가능 합니다.");
+            alert("강의날짜 하루 전날부터는 취소가 불가능 합니다.");
           }
           location.reload();
         } else {
-          alert("작업에 실패하였습니다.");
+          alert("삭제에 실패하였습니다.");
         }
+      })
+      .catch(() => {
+        alert("취소 요청 중 오류가 발생했습니다.");
       });
   }
 }


### PR DESCRIPTION
## 변경 내용

접수내역 페이지 달력에서 멘토링 취소가 정상적으로 동작하지 않던 문제를 수정했습니다.

기존에는 상세 페이지에서 취소 정보를 추출해 별도 엔드포인트로 취소를 시도하고 있었는데, 실제 사이트의 취소 흐름과 달라 실패하는 경우가 있었습니다.  
이를 접수내역 표의 실제 취소 정보(`delDate(...)`)를 기준으로 동작하도록 변경했습니다.

추가로, 취소 불가 버튼이 더 명확하게 보이도록 비활성 스타일도 정리했습니다.

## 상세 수정

- 접수내역 표에서 취소 가능 항목의 `cancelId`, `cancelGubun` 파싱
- 취소 요청을 실제 사이트 흐름(`/sw/mypage/userAnswer/cancel.json` / `window.delDate`)에 맞게 수정
- 취소 불가 항목은 달력에서도 비활성화 처리
- 지난 항목과 취소 불가 항목의 상태 클래스를 분리할 수 있도록 정리
- 비활성 취소 버튼 스타일 개선