### PR TITLE
feat: add functionality for viewing past two weeks in calendar

### DIFF
--- a/src/calendar.css
+++ b/src/calendar.css
@@ -33,6 +33,29 @@
   white-space: nowrap;
 }
 
+/* Past weeks button */
+.past-btn-cell {
+  grid-column: 1 / -1;
+  text-align: center;
+}
+
+.past-btn {
+  width: 100%;
+  background-color: #00000011;
+  color: #222;
+  font-size: 0.9em;
+  font-weight: bold;
+  padding: 6px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.past-btn:hover {
+  background-color: #114c9dcc;
+  color: white;
+}
+
 /* Lecture styling */
 .calendar-lecture {
   font-size: 0.8em;

--- a/src/content.js
+++ b/src/content.js
@@ -99,6 +99,63 @@ function createCalendarLectureElement(
   return lectureElement;
 }
 
+function createDayCell(date, today, lectures) {
+  const weekday = ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
+  const dayStr = `${date.getMonth() + 1}월 ${date.getDate()}일 (${weekday})`;
+  const isToday = date.toDateString() === today.toDateString();
+  const filteredEvents = lectures.filter(
+    (ev) => ev.startAt.toDateString() === date.toDateString(),
+  );
+
+  const cell = document.createElement("div");
+  cell.className = `calendar-cell ${isToday ? "today-bg" : ""}`.trim();
+
+  const dateElement = document.createElement("div");
+  dateElement.className =
+    `calendar-date ${isToday ? "today-text" : ""}`.trim();
+  dateElement.textContent = `${dayStr}${isToday ? " [오늘]" : ""}`;
+  cell.appendChild(dateElement);
+
+  filteredEvents.forEach((ev, index) => {
+    const isConflict =
+      (index > 0 && filteredEvents[index - 1].endAt > ev.startAt) ||
+      (index < filteredEvents.length - 1 &&
+        filteredEvents[index + 1].startAt < ev.endAt);
+    const isAlreadyPassed = ev.startAt < today;
+    const isEnded = ev.endAt < today;
+    cell.appendChild(
+      createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded),
+    );
+  });
+
+  return cell;
+}
+
+function createPastButton(wrapper, startDate, today) {
+  let currentStart = new Date(startDate);
+
+  const cell = document.createElement("div");
+  cell.className = "calendar-cell past-btn-cell";
+
+  const btn = document.createElement("button");
+  btn.className = "past-btn";
+  btn.textContent = "⬆ 이전 2주 보기";
+
+  btn.addEventListener("click", () => {
+    currentStart.setDate(currentStart.getDate() - 14);
+    const insertBefore = cell.nextSibling;
+    for (let i = 0; i < 14; i++) {
+      const date = new Date(currentStart);
+      date.setDate(currentStart.getDate() + i);
+      wrapper.insertBefore(createDayCell(date, today, lectures), insertBefore);
+    }
+    updateCalendarElement();
+  });
+
+  cell.appendChild(btn);
+  return cell;
+}
+
 async function generateCalendarElement() {
   const today = new Date();
   const startDate = new Date(today);
@@ -108,40 +165,12 @@ async function generateCalendarElement() {
 
   lectures = await getAllLectures();
 
+  wrapper.appendChild(createPastButton(wrapper, startDate, today));
+
   for (let i = 0; i < 28; i++) {
     const date = new Date(startDate);
     date.setDate(startDate.getDate() + i);
-
-    const weekday = ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
-    const dayStr = `${date.getMonth() + 1}월 ${date.getDate()}일 (${weekday})`;
-    const isToday = date.toDateString() === today.toDateString();
-    const filteredEvents = lectures.filter((ev) => {
-      const eventDate = new Date(ev.startAt);
-      return eventDate.toDateString() === date.toDateString();
-    });
-
-    const cell = document.createElement("div");
-    cell.className = `calendar-cell ${isToday ? "today-bg" : ""}`.trim();
-
-    const dateElement = document.createElement("div");
-    dateElement.className =
-      `calendar-date ${isToday ? "today-text" : ""}`.trim();
-    dateElement.textContent = `${dayStr}${isToday ? " [오늘]" : ""}`;
-    cell.appendChild(dateElement);
-
-    filteredEvents.forEach((ev, index) => {
-      const isConflict =
-        (index > 0 && filteredEvents[index - 1].endAt > ev.startAt) ||
-        (index < filteredEvents.length - 1 &&
-          filteredEvents[index + 1].startAt < ev.endAt);
-      const isAlreadyPassed = ev.startAt < today;
-      const isEnded = ev.endAt < today;
-      cell.appendChild(
-        createCalendarLectureElement(ev, isConflict, isAlreadyPassed, isEnded),
-      );
-    });
-
-    wrapper.appendChild(cell);
+    wrapper.appendChild(createDayCell(date, today, lectures));
   }
 
   return wrapper;
@@ -185,6 +214,7 @@ function generateGoogleCalendarURL(lecture) {
 async function updateCalendarElement() {
   const eventElems = document.querySelectorAll("div.calendar-lecture");
   for (let ev of eventElems) {
+    if (ev.querySelector('[data-role="loc"]').innerText !== "장소 로딩중..") continue;
     const res = await fetch(ev.querySelector("a").href, {
       credentials: "include",
     });

--- a/src/content.js
+++ b/src/content.js
@@ -111,8 +111,7 @@ function createDayCell(date, today, lectures) {
   cell.className = `calendar-cell ${isToday ? "today-bg" : ""}`.trim();
 
   const dateElement = document.createElement("div");
-  dateElement.className =
-    `calendar-date ${isToday ? "today-text" : ""}`.trim();
+  dateElement.className = `calendar-date ${isToday ? "today-text" : ""}`.trim();
   dateElement.textContent = `${dayStr}${isToday ? " [오늘]" : ""}`;
   cell.appendChild(dateElement);
 
@@ -214,7 +213,8 @@ function generateGoogleCalendarURL(lecture) {
 async function updateCalendarElement() {
   const eventElems = document.querySelectorAll("div.calendar-lecture");
   for (let ev of eventElems) {
-    if (ev.querySelector('[data-role="loc"]').innerText !== "장소 로딩중..") continue;
+    if (ev.querySelector('[data-role="loc"]').innerText !== "장소 로딩중..")
+      continue;
     const res = await fetch(ev.querySelector("a").href, {
       credentials: "include",
     });


### PR DESCRIPTION
## Summary

과거 멘토링 기록을 확인할 수 있도록 달력 상단에 "⬆ 이전 2주 보기"버튼을 추가했습니다. 
버튼을 클릭할 때마다 2주씩 과거 데이터가 화면에 누적되어 표시됩니다.

## Changes

### src/content.js
- **`createDayCell(date, today, lectures)` 함수 추가**: 날짜 셀 생성 로직을 별도 함수로 분리하여 재사용 가능하게 구조화
- **`createPastButton(wrapper, startDate, today)` 함수 추가**: 과거 2주 데이터 조회 버튼 구현
  - 클로저로 현재 범위를 추적해 반복 클릭 시에도 정상 동작
  - `getAllLectures()`는 한 번만 호출되고 기존 데이터 재사용
  - 새로운 셀 삽입 후 자동으로 `updateCalendarElement()` 호출
- **`generateCalendarElement()` 함수 수정**: 
  - 루프 상단에 버튼 셀 삽입
  - 루프 본체를 `createDayCell()` 호출로 단순화
- **`updateCalendarElement()` 함수 수정**:
  - 이미 처리된 요소를 건너뛰는 조건 추가 (중복 fetch 및 이벤트 리스너 중복 등록 방지)
  - 버튼 클릭 시 새로 추가된 셀의 장소/인원수도 정상 로드됨

### src/calendar.css
- **`.past-btn-cell` 스타일 추가**: 버튼이 7열 전체에 걸치도록 설정
- **`.past-btn` 스타일 추가**: 기존 버튼 스타일과 통일된 디자인

## How it works

1. 초기 로드 시 이번 주 일요일부터 28일(4주)치 달력 표시
2. "⬆ 이전 2주 보기" 버튼 클릭 → 2주 전 데이터가 현재 달력 위에 추가됨
3. 버튼을 반복 클릭하면 계속해서 더 오래된 데이터 조회 가능
4. 과거 데이터도 현재 데이터와 동일하게 ICS 내보내기, 구글 캘린더 추가, 접수 취소 기능 지원

## Technical Details

- `getAllLectures()` 재호출 방지: 모듈 변수 `lectures`를 재사용하여 서버 부하 최소화
- 이벤트 리스너 중복 등록 방지: `updateCalendarElement()`에서 "장소 로딩중.." 상태인 요소만 처리
- 기존 코드와의 호환성: 새로운 함수 추가와 최소한의 수정으로 기존 동작 유지