### PR TITLE
chore: 사소한 디자인 수정

### DIFF
--- a/src/calendar.css
+++ b/src/calendar.css
@@ -82,11 +82,10 @@
   background: #ffe8e8;
 }
 
-/* Keep past lectures muted without making history hard to read. */
 .ended {
   background: #f8f8f8;
   color: #666;
-  opacity: 0.82;
+  opacity: 0.7; /* dimming amount */
 }
 
 .ended .text-title,

--- a/src/content.js
+++ b/src/content.js
@@ -144,7 +144,7 @@ function createPastButton(wrapper, startDate, today) {
 
   const resetBtn = document.createElement("button");
   resetBtn.className = "past-btn";
-  resetBtn.textContent = "⭯ 이번주부터 보기";
+  resetBtn.textContent = "↩ 이번주부터 보기";
   resetBtn.hidden = true;
 
   btn.addEventListener("click", () => {

--- a/src/content.js
+++ b/src/content.js
@@ -138,16 +138,16 @@ function createPastButton(wrapper, startDate, today) {
   const cell = document.createElement("div");
   cell.className = "calendar-cell past-btn-cell";
 
-  const btn = document.createElement("button");
-  btn.className = "past-btn";
-  btn.textContent = "⬆ 이전 2주 보기";
+  const pastBtn = document.createElement("button");
+  pastBtn.className = "past-btn";
+  pastBtn.textContent = "⬆ 이전 2주 보기";
 
   const resetBtn = document.createElement("button");
   resetBtn.className = "past-btn";
   resetBtn.textContent = "↩ 이번주부터 보기";
   resetBtn.hidden = true;
 
-  btn.addEventListener("click", () => {
+  pastBtn.addEventListener("click", () => {
     currentStart.setDate(currentStart.getDate() - 14);
     const insertBefore = cell.nextSibling;
     for (let i = 0; i < 14; i++) {
@@ -170,7 +170,7 @@ function createPastButton(wrapper, startDate, today) {
     resetBtn.hidden = true;
   });
 
-  cell.append(btn, resetBtn);
+  cell.append(pastBtn, resetBtn);
   return cell;
 }
 


### PR DESCRIPTION
## 작업 내용
- 기능적인 변화 없는 사소한 수정들입니다
  - 렌더링 깨지는 유니코드 아이콘 변경
  - 모호한 변수명 수정 (`btn -> pastBtn`)
  - 지나간 강의 카드 dimming amount 소폭 증가 (`opacity: 0.82 -> 0.7`)

### AS-IS
- Firefox
<img width="2876" height="718" alt="Blur_Screenshot 2026-04-22 at 5 29 56 PM" src="https://github.com/user-attachments/assets/c1179d42-148c-4d77-970e-d2908ed88602" />

---

- Chrome
<img width="2908" height="724" alt="Blur_Screenshot 2026-04-22 at 5 51 33 PM" src="https://github.com/user-attachments/assets/e18582fb-fa6d-4fee-abf9-2b91c402ab0b" />

### TO-BE
<img width="2872" height="728" alt="Blur_Screenshot 2026-04-22 at 5 28 43 PM" src="https://github.com/user-attachments/assets/34923136-dc0c-4e81-98d1-42f8254f94a3" />
