### PR TITLE
feat: 팝업 파일에 부산 소마 추가

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -15,7 +15,14 @@
   <div style="margin-bottom: 10px;">
     <a href="https://www.swmaestro.ai/sw/mypage/userAnswer/history.do?menuNo=200047" target="_blank" rel="noreferrer"
       style="color: #333; font-weight: bold; display: flex; align-items: center;">
-      🗓️ 멘토링/특강 접수 내역 확인하기
+      🏙️ 멘토링/특강 접수 내역 확인하기(서울 센터)
+    </a>
+  </div>
+
+  <div style="margin-bottom: 10px;">
+    <a href="https://www.swmaestro.ai/busan/sw/mypage/userAnswer/history.do?menuNo=200047" target="_blank"
+      rel="noreferrer" style="color: #333; font-weight: bold; display: flex; align-items: center;">
+      🌊 멘토링/특강 접수 내역 확인하기(부산 센터)
     </a>
   </div>
 


### PR DESCRIPTION
### 📝 변경 내용
- 기존 확장 프로그램 팝업 클릭 시 서울 센터로만 이동되던 것을 부산 센터 추가해놨습니다
- 서울 센터, 부산 센터 구별을 위해 아이콘을 변경했습니다


### 📸 스크린샷
- 기존안
<img width="293" height="149" alt="image" src="https://github.com/user-attachments/assets/c49dca95-7338-4ea4-aac7-a50b852e55ce" />
- 부산 센터 연수생이 "멘토링/특강 접수 내역 확인하기" 클릭 시
<img width="1279" height="668" alt="image" src="https://github.com/user-attachments/assets/81073895-efe9-444f-a32f-d653ee343fa2" />



- 변경안
<img width="294" height="170" alt="image" src="https://github.com/user-attachments/assets/d67a2ea6-43f3-4873-9619-cd14c7a9b05c" />
- 부산 센터 연수생이 "멘토링/특강 접수 내역 확인하기(부산 센터)" 클릭 시
<img width="1279" height="672" alt="image" src="https://github.com/user-attachments/assets/4ce2f622-d123-49cb-953d-924654b66336" />
