### PR TITLE
feat: 멘토링/특강 목록에 온라인/오프라인 진행방식 필터 추가 (#46)

### DIFF
--- a/src/calendar.css
+++ b/src/calendar.css
@@ -276,3 +276,16 @@
 .ended .cancel-btn.unavailable:hover {
   background: #ececec;
 }
+
+/* Mode filter tabs */
+ul.tabs-sort li a {
+  font-weight: 500 !important;
+  transition:
+    color,
+    opacity 0.5s ease;
+}
+
+ul.tabs-sort li:not(.active) a:hover {
+  color: #114c9d !important;
+  opacity: 0.7;
+}

--- a/src/lecture.js
+++ b/src/lecture.js
@@ -1,6 +1,111 @@
 const lecturePopupDetailCache = new Map();
 const lecturePopupDetailRequests = new Map();
 
+// ── Online / Offline mode filter ─────────────────────────────────────────────
+
+const FILTER_STORAGE_KEY = "soma-mode-filter";
+
+function saveModeFilter(value) {
+  sessionStorage.setItem(FILTER_STORAGE_KEY, value);
+}
+
+function loadSavedModeFilter() {
+  return sessionStorage.getItem(FILTER_STORAGE_KEY) ?? "all";
+}
+
+let currentModeFilter = loadSavedModeFilter();
+const rowModeMap = new Map();
+let modeFilterLoading = false;
+
+function getListRows() {
+  return document.querySelectorAll(
+    "#listFrm > div.boardlist.mt50 > table > tbody > tr",
+  );
+}
+
+async function loadAllRowModes() {
+  const fetches = Array.from(getListRows()).map(async (row) => {
+    const link = row.querySelector('a[href*="mentoLec/view.do"]');
+    if (!link) return;
+    try {
+      const detail = await fetchCalendarPopupDetail(link.href);
+      rowModeMap.set(row, detail.mode ?? null);
+    } catch {
+      rowModeMap.set(row, null);
+    }
+  });
+  await Promise.all(fetches);
+}
+
+function applyModeFilter() {
+  for (const row of getListRows()) {
+    if (currentModeFilter === "all") {
+      row.style.display = "";
+      continue;
+    }
+    const mode = rowModeMap.get(row);
+    if (mode === undefined) {
+      row.style.display = "";
+      continue;
+    }
+    const isOnline = mode?.includes("온라인") ?? false;
+    row.style.display =
+      (currentModeFilter === "online") === isOnline ? "" : "none";
+  }
+}
+
+function insertModeFilterUI() {
+  const existingTabs = document.querySelector("ul.tabs-sort");
+  if (!existingTabs) return;
+
+  const modeTabsList = document.createElement("ul");
+  modeTabsList.className = "tabs-sort soma-mode-tabs";
+
+  for (const { text, value } of [
+    { text: "전체", value: "all" },
+    { text: "온라인", value: "online" },
+    { text: "오프라인", value: "offline" },
+  ]) {
+    const li = document.createElement("li");
+    li.dataset.modeFilter = value;
+    if (value === currentModeFilter) li.classList.add("active");
+
+    const a = document.createElement("a");
+    a.href = "javascript:void(0);";
+    a.textContent = text;
+
+    a.addEventListener("click", async () => {
+      if (modeFilterLoading) return;
+
+      modeTabsList
+        .querySelectorAll("li[data-mode-filter]")
+        .forEach((item) => item.classList.remove("active"));
+      li.classList.add("active");
+      currentModeFilter = value;
+      saveModeFilter(value);
+
+      if (value !== "all" && rowModeMap.size === 0) {
+        modeFilterLoading = true;
+        modeTabsList.style.opacity = "0.6";
+        modeTabsList.style.pointerEvents = "none";
+        await loadAllRowModes();
+        modeFilterLoading = false;
+        modeTabsList.style.opacity = "";
+        modeTabsList.style.pointerEvents = "";
+      }
+
+      applyModeFilter();
+    });
+
+    li.appendChild(a);
+    modeTabsList.appendChild(li);
+  }
+
+  existingTabs.after(modeTabsList);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 // 달력 항목에서 팝업 조회에 필요한 요소를 추출
 function getCalendarPopupElements(item) {
   const trigger =
@@ -65,6 +170,7 @@ function renderCalendarPopupDetail(container, detail) {
     : detail.npeople || "정보 없음";
   const fields = [
     ["시간", detail.timeStr || "정보 없음"],
+    ["진행방식", detail.mode || "정보 없음"],
     ["장소", detail.loc || "정보 없음"],
     ["인원", peopleText],
   ];
@@ -235,6 +341,25 @@ function renderConflictLectures(popupElement, conflictingLectures) {
     lectureElement.append(titleRow, authorRow, timeRow);
     popupElement.appendChild(lectureElement);
   }
+}
+
+insertModeFilterUI();
+
+if (currentModeFilter !== "all") {
+  const modeTabsList = document.querySelector("ul.soma-mode-tabs");
+  modeFilterLoading = true;
+  if (modeTabsList) {
+    modeTabsList.style.opacity = "0.6";
+    modeTabsList.style.pointerEvents = "none";
+  }
+  loadAllRowModes().then(() => {
+    modeFilterLoading = false;
+    if (modeTabsList) {
+      modeTabsList.style.opacity = "";
+      modeTabsList.style.pointerEvents = "";
+    }
+    applyModeFilter();
+  });
 }
 
 getAllLectures().then((lectures) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,6 +101,7 @@ function extractLectureDetailFromHTML(html) {
   const totalCount = npeople?.match(/(\d+)/)?.[1] || null;
   return {
     loc: getTopValue("장소"),
+    mode: getTopValue("진행방식"),
     npeople,
     timeStr: getTopValue("강의날짜"),
     appliedCount,


### PR DESCRIPTION
### 관련 이슈

Closes #46

### 변경 내용

- `utils.js`: 강의 상세 HTML에서 `진행방식` 필드 파싱 추가
- `lecture.js`: 전체 / 온라인 / 오프라인 필터 탭 UI 삽입 및 필터 로직 구현
  - `sessionStorage`로 페이지 이동 후에도 필터 선택 상태 유지
  - 필터 활성화 시 `Promise.all`로 상세 페이지 병렬 fetch
  - 로딩 중 탭 비활성화(opacity + pointerEvents)로 중복 클릭 방지
- `calendar.css`: 필터 탭 호버 스타일 추가

### 스크린샷

**Before**
<img width="209" height="58" alt="image" src="https://github.com/user-attachments/assets/bf5564f7-6714-463a-9eb9-417e4e049d0e" /> 

**After**
<img width="439" height="56" alt="image" src="https://github.com/user-attachments/assets/0f69ddef-018b-44e6-a509-645a916467c7" />

### 성능 확인

- **신규 네트워크 호출**: 필터가 "전체"인 경우 추가 호출 없음. 온라인/오프라인 탭 **첫 클릭 시에만** 전체 강의 상세 페이지를 `Promise.all`로 병렬 fetch. 이후 캐시(`lecturePopupDetailCache`) 재사용으로 추가 호출 없음.
- **N+1 없음**: 직렬 fetch 대신 `Promise.all` 병렬화 적용.

### 한계점

소마 사이트의 목록 페이지에서 진행방식(온라인/오프라인) 정보를 직접 제공하지 않아,
**온라인/오프라인 탭 클릭 시 각 강의의 상세 페이지를 개별 fetch하여 진행방식을 파싱하는 방식으로 구현**되었습니다. 
이로 인해 필터 적용까지 짧은 딜레이와 깜빡임이 발생할 수 있습니다. 

### PR 체크리스트

- [x] 로컬에서 Prettier 체크 통과
- [x] `mentoLec/list.do` 페이지에서 필터 동작 직접 확인
- [x] Before/After 스크린샷 첨부
- [x] `manifest.json` version 미수정