### PR TITLE
refactor: 강의 상세 조회 공통 캐시 통합 및 동시 요청 제한 (#48)

### DIFF
--- a/src/calendar.css
+++ b/src/calendar.css
@@ -289,3 +289,14 @@ ul.tabs-sort li:not(.active) a:hover {
   color: #114c9d !important;
   opacity: 0.7;
 }
+
+.calendarPop a.close {
+  box-shadow: none !important;
+  margin-top: 10px !important;
+  margin-right: 8px !important;
+}
+
+.calendarPop a.close:hover {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  box-shadow: none !important;
+}

--- a/src/calendar.css
+++ b/src/calendar.css
@@ -276,3 +276,16 @@
 .ended .cancel-btn.unavailable:hover {
   background: #ececec;
 }
+
+/* Mode filter tabs */
+ul.tabs-sort li a {
+  font-weight: 500 !important;
+  transition:
+    color,
+    opacity 0.5s ease;
+}
+
+ul.tabs-sort li:not(.active) a:hover {
+  color: #114c9d !important;
+  opacity: 0.7;
+}

--- a/src/lecture.js
+++ b/src/lecture.js
@@ -1,6 +1,3 @@
-const lecturePopupDetailCache = new Map();
-const lecturePopupDetailRequests = new Map();
-
 // ── Online / Offline mode filter ─────────────────────────────────────────────
 
 const FILTER_STORAGE_KEY = "soma-mode-filter";
@@ -24,17 +21,18 @@ function getListRows() {
 }
 
 async function loadAllRowModes() {
-  const fetches = Array.from(getListRows()).map(async (row) => {
+  const rows = Array.from(getListRows()).filter((row) =>
+    row.querySelector('a[href*="mentoLec/view.do"]'),
+  );
+  await withConcurrency(rows, 5, async (row) => {
     const link = row.querySelector('a[href*="mentoLec/view.do"]');
-    if (!link) return;
     try {
-      const detail = await fetchCalendarPopupDetail(link.href);
+      const detail = await getLectureDetail(link.href);
       rowModeMap.set(row, detail.mode ?? null);
     } catch {
       rowModeMap.set(row, null);
     }
   });
-  await Promise.all(fetches);
 }
 
 function applyModeFilter() {
@@ -193,35 +191,8 @@ function renderCalendarPopupDetail(container, detail) {
   }
 }
 
-// 상세 페이지를 조회하고 결과를 캐시
-async function fetchCalendarPopupDetail(url) {
-  if (lecturePopupDetailCache.has(url)) {
-    return lecturePopupDetailCache.get(url);
-  }
-
-  if (lecturePopupDetailRequests.has(url)) {
-    return lecturePopupDetailRequests.get(url);
-  }
-
-  const request = fetch(url, { credentials: "include" })
-    .then((res) => {
-      if (!res.ok) {
-        throw new Error(`Failed to fetch popup detail: ${res.status}`);
-      }
-
-      return res.text();
-    })
-    .then((html) => {
-      const detail = extractLectureDetailFromHTML(html);
-      lecturePopupDetailCache.set(url, detail);
-      return detail;
-    })
-    .finally(() => {
-      lecturePopupDetailRequests.delete(url);
-    });
-
-  lecturePopupDetailRequests.set(url, request);
-  return request;
+function fetchCalendarPopupDetail(url) {
+  return getLectureDetail(url);
 }
 
 // 현재 열린 팝업에 상세 정보를 채워 넣기
@@ -233,7 +204,7 @@ async function enrichCalendarPopup(item) {
   }
 
   const container = getCalendarPopupDetailContainer(popup);
-  const cachedDetail = lecturePopupDetailCache.get(detailLink.href);
+  const cachedDetail = detailMemCache.get(detailLink.href);
 
   if (cachedDetail) {
     renderCalendarPopupDetail(container, cachedDetail);

--- a/src/lecture.js
+++ b/src/lecture.js
@@ -1,6 +1,111 @@
 const lecturePopupDetailCache = new Map();
 const lecturePopupDetailRequests = new Map();
 
+// ── Online / Offline mode filter ─────────────────────────────────────────────
+
+const FILTER_STORAGE_KEY = "soma-mode-filter";
+
+function saveModeFilter(value) {
+  sessionStorage.setItem(FILTER_STORAGE_KEY, value);
+}
+
+function loadSavedModeFilter() {
+  return sessionStorage.getItem(FILTER_STORAGE_KEY) ?? "all";
+}
+
+let currentModeFilter = loadSavedModeFilter();
+const rowModeMap = new Map();
+let modeFilterLoading = false;
+
+function getListRows() {
+  return document.querySelectorAll(
+    "#listFrm > div.boardlist.mt50 > table > tbody > tr",
+  );
+}
+
+async function loadAllRowModes() {
+  const fetches = Array.from(getListRows()).map(async (row) => {
+    const link = row.querySelector('a[href*="mentoLec/view.do"]');
+    if (!link) return;
+    try {
+      const detail = await fetchCalendarPopupDetail(link.href);
+      rowModeMap.set(row, detail.mode ?? null);
+    } catch {
+      rowModeMap.set(row, null);
+    }
+  });
+  await Promise.all(fetches);
+}
+
+function applyModeFilter() {
+  for (const row of getListRows()) {
+    if (currentModeFilter === "all") {
+      row.style.display = "";
+      continue;
+    }
+    const mode = rowModeMap.get(row);
+    if (mode === undefined) {
+      row.style.display = "";
+      continue;
+    }
+    const isOnline = mode?.includes("온라인") ?? false;
+    row.style.display =
+      (currentModeFilter === "online") === isOnline ? "" : "none";
+  }
+}
+
+function insertModeFilterUI() {
+  const existingTabs = document.querySelector("ul.tabs-sort");
+  if (!existingTabs) return;
+
+  const modeTabsList = document.createElement("ul");
+  modeTabsList.className = "tabs-sort soma-mode-tabs";
+
+  for (const { text, value } of [
+    { text: "전체", value: "all" },
+    { text: "온라인", value: "online" },
+    { text: "오프라인", value: "offline" },
+  ]) {
+    const li = document.createElement("li");
+    li.dataset.modeFilter = value;
+    if (value === currentModeFilter) li.classList.add("active");
+
+    const a = document.createElement("a");
+    a.href = "javascript:void(0);";
+    a.textContent = text;
+
+    a.addEventListener("click", async () => {
+      if (modeFilterLoading) return;
+
+      modeTabsList
+        .querySelectorAll("li[data-mode-filter]")
+        .forEach((item) => item.classList.remove("active"));
+      li.classList.add("active");
+      currentModeFilter = value;
+      saveModeFilter(value);
+
+      if (value !== "all" && rowModeMap.size === 0) {
+        modeFilterLoading = true;
+        modeTabsList.style.opacity = "0.6";
+        modeTabsList.style.pointerEvents = "none";
+        await loadAllRowModes();
+        modeFilterLoading = false;
+        modeTabsList.style.opacity = "";
+        modeTabsList.style.pointerEvents = "";
+      }
+
+      applyModeFilter();
+    });
+
+    li.appendChild(a);
+    modeTabsList.appendChild(li);
+  }
+
+  existingTabs.after(modeTabsList);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 // 달력 항목에서 팝업 조회에 필요한 요소를 추출
 function getCalendarPopupElements(item) {
   const trigger =
@@ -65,6 +170,7 @@ function renderCalendarPopupDetail(container, detail) {
     : detail.npeople || "정보 없음";
   const fields = [
     ["시간", detail.timeStr || "정보 없음"],
+    ["진행방식", detail.mode || "정보 없음"],
     ["장소", detail.loc || "정보 없음"],
     ["인원", peopleText],
   ];
@@ -235,6 +341,25 @@ function renderConflictLectures(popupElement, conflictingLectures) {
     lectureElement.append(titleRow, authorRow, timeRow);
     popupElement.appendChild(lectureElement);
   }
+}
+
+insertModeFilterUI();
+
+if (currentModeFilter !== "all") {
+  const modeTabsList = document.querySelector("ul.soma-mode-tabs");
+  modeFilterLoading = true;
+  if (modeTabsList) {
+    modeTabsList.style.opacity = "0.6";
+    modeTabsList.style.pointerEvents = "none";
+  }
+  loadAllRowModes().then(() => {
+    modeFilterLoading = false;
+    if (modeTabsList) {
+      modeTabsList.style.opacity = "";
+      modeTabsList.style.pointerEvents = "";
+    }
+    applyModeFilter();
+  });
 }
 
 getAllLectures().then((lectures) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,6 +101,7 @@ function extractLectureDetailFromHTML(html) {
   const totalCount = npeople?.match(/(\d+)/)?.[1] || null;
   return {
     loc: getTopValue("장소"),
+    mode: getTopValue("진행방식"),
     npeople,
     timeStr: getTopValue("강의날짜"),
     appliedCount,

--- a/src/utils.js
+++ b/src/utils.js
@@ -191,6 +191,62 @@ function getLectureId(url) {
   return qustnrSn;
 }
 
+const DETAIL_CACHE_PREFIX = "soma-detail-v1:";
+const STABLE_FIELDS = ["mode", "loc", "timeStr", "npeople", "totalCount"];
+const detailMemCache = new Map();
+const detailInflight = new Map();
+
+async function getLectureDetail(url) {
+  if (detailMemCache.has(url)) return detailMemCache.get(url);
+  if (detailInflight.has(url)) return detailInflight.get(url);
+
+  const sessionKey = DETAIL_CACHE_PREFIX + url;
+  try {
+    const raw = sessionStorage.getItem(sessionKey);
+    if (raw) {
+      const stable = JSON.parse(raw);
+      detailMemCache.set(url, stable);
+      return stable;
+    }
+  } catch {}
+
+  const promise = fetch(url, { credentials: "include" })
+    .then((res) => {
+      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+      return res.text();
+    })
+    .then((html) => {
+      const detail = extractLectureDetailFromHTML(html);
+      detailMemCache.set(url, detail);
+      const stable = Object.fromEntries(
+        STABLE_FIELDS.map((k) => [k, detail[k] ?? null]),
+      );
+      try {
+        sessionStorage.setItem(sessionKey, JSON.stringify(stable));
+      } catch {}
+      return detail;
+    })
+    .finally(() => detailInflight.delete(url));
+
+  detailInflight.set(url, promise);
+  return promise;
+}
+
+async function withConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+  return results;
+}
+
 function cancelApply(cancelId, qustnrSn, gubun = "mentoLec") {
   if (!cancelId || !qustnrSn) {
     alert("취소할 수 없는 항목입니다.");


### PR DESCRIPTION
### 관련 이슈

Closes #48

### 변경 내용

**utils.js**
- `getLectureDetail(url)` 공통 상세 조회 함수 추가: 메모리 캐시 → `sessionStorage(안정 필드)` → fetch 순서로 조회하며, 동일 URL 동시 요청을 하나의 Promise로 공유해 중복 요청 방지
- `withConcurrency(items, limit, fn)` 유틸리티 추가: 최대 N개 동시 실행 제한

**lecture.js**
- `lecturePopupDetailCache` / `lecturePopupDetailRequests` Map 제거 후 `getLectureDetail()`로 위임
- `loadAllRowModes()`의 무제한 `Promise.all`을 `withConcurrency(5)`로 교체해 동시 요청 수 제한

**calendar.css**
- `calendarPop` 닫기 버튼 상단/우측 여백 추가
- `calendarPop` 닫기 버튼 호버 시 그림자 제거 및 연한 회색 배경 추가

### 스크린샷

**Before**
<img width="339" height="146" alt="image" src="https://github.com/user-attachments/assets/47baf5c3-efdf-42f7-8de1-13c07c307670" />

**After**
<img width="338" height="273" alt="image" src="https://github.com/user-attachments/assets/3dec35a9-98a7-4546-a977-1002e0ac3d11" />

### 성능 확인

- **신규 네트워크 호출**: 필터가 "전체"인 경우 추가 호출 없음. 온라인/오프라인 탭 첫 클릭 시에만 상세 페이지 fetch 발생, 이후 캐시 재사용으로 추가 호출 없음.
- **동시 요청 제한**: 기존 무제한 `Promise.all` 방식에서 최대 5개 동시 요청으로 제한.
- **세션 캐시**: 안정 필드(mode, loc, timeStr, npeople, totalCount)를 sessionStorage에 저장하여 새로고침 및 페이지 이동 후에도 재사용. 신청 인원수·개설 승인 상태 등 휘발성 필드는 캐시하지 않음.

### 한계점

소마 사이트의 목록 페이지에서 진행방식 정보를 직접 제공하지 않아, 온라인/오프라인 탭 첫 클릭 시 각 강의의 상세 페이지를 개별 fetch하여 파싱하는 N+1 구조는 유지됩니다. 캘린더 페이지(`content.js`)는 개설 승인 상태·신청 인원수의 정확성이 필요하여 `getLectureDetail()` 미적용, 기존 직렬 fetch 방식을 유지합니다.

### PR 체크리스트

- [x] 로컬에서 Prettier 체크 통과
- [x] `mentoLec/list.do` 페이지에서 필터 동작 직접 확인
- [x] `manifest.json` version 미수정